### PR TITLE
Add Vertical Annotations to the Visualization Editor

### DIFF
--- a/src/components/chart.py
+++ b/src/components/chart.py
@@ -123,10 +123,10 @@ def chart(control_values={}):
       line_value = line.get('value')
       line_label = line.get('label', '')
       line_color = line.get('color', '#222222')
-    
+
       if not line_value:
         continue
-    
+
       if axis == 'y':
         # horizontal lines
         for yaxis_name in fig.select_yaxes():
@@ -145,7 +145,7 @@ def chart(control_values={}):
         if isinstance(line_value, str):
           line_value = pd.to_datetime(line_value).date()
         elif isinstance(line_value, datetime.date):
-          line_value = datetime.datetime.combine(line_value, datetime.time())    
+          line_value = datetime.datetime.combine(line_value, datetime.time())
 
         for xaxis_name in fig.select_xaxes():
           fig.add_shape(
@@ -168,11 +168,14 @@ def chart(control_values={}):
             showarrow=False,
             font=dict(color=line_color),
             xanchor='left',
-            yanchor='bottom'
+            yanchor='bottom',
           )
 
   fig.update_layout(
-    hovermode='x unified', height=300 * num_rows, title='Forecast values over time (by scenario)', uirevision='df',
+    hovermode='x unified',
+    height=300 * num_rows,
+    title='Forecast values over time (by scenario)',
+    uirevision='df',
   )
   fig.update_xaxes(showspikes=True, spikemode='across', spikesnap='cursor')
   fig.update_yaxes(showspikes=True, spikemode='across')

--- a/src/components/chart.py
+++ b/src/components/chart.py
@@ -161,14 +161,14 @@ def chart(control_values={}):
 
           fig.add_annotation(
             x=line_value,
-            y=1,  # top
+            y=-0.033,  # [0, 1] ~ [bottom, top]
             xref='x',
             yref='paper',
             text=line_label,
             showarrow=False,
             font=dict(color=line_color),
-            xanchor='left',
-            yanchor='bottom',
+            xanchor='center',
+            yanchor='top',
           )
 
   fig.update_layout(

--- a/src/components/chart.py
+++ b/src/components/chart.py
@@ -1,3 +1,4 @@
+import datetime
 from dash import dcc
 import pandas as pd
 from src.util.data import build_dataset_path, collect_data
@@ -117,22 +118,58 @@ def chart(control_values={}):
       col=1,
     )
 
-  for line in annotations:
-    if line.get('value'):
+    for line in annotations:
+      axis = line.get('axis', 'y')
       line_value = line.get('value')
       line_label = line.get('label', '')
       line_color = line.get('color', '#222222')
+    
+      if not line_value:
+        continue
+    
+      if axis == 'y':
+        # horizontal lines
+        for yaxis_name in fig.select_yaxes():
+          fig.add_hline(
+            y=line_value,
+            line_dash='dot',
+            line_color=line_color,
+            line_width=1,
+            annotation_text=line_label,
+            annotation_position='top left',
+            annotation_font_color=line_color,
+          )
+      elif axis == 'x':
+        # vertical lines
+        # coerce a string to a timestamp
+        if isinstance(line_value, str):
+          line_value = pd.to_datetime(line_value).date()
+        elif isinstance(line_value, datetime.date):
+          line_value = datetime.datetime.combine(line_value, datetime.time())    
 
-      for yaxis_name in fig.select_yaxes():
-        fig.add_hline(
-          y=line_value,
-          line_dash='dot',
-          line_color=line_color,
-          line_width=1,
-          annotation_text=line_label,
-          annotation_position='top left',
-          annotation_font_color=line_color,
-        )
+        for xaxis_name in fig.select_xaxes():
+          fig.add_shape(
+            type='line',
+            x0=line_value,
+            x1=line_value,
+            y0=0,
+            y1=1,
+            xref='x',
+            yref='paper',  # span entire height? reduces labels
+            line=dict(color=line_color, dash='dot', width=1),
+          )
+
+          fig.add_annotation(
+            x=line_value,
+            y=1,  # top
+            xref='x',
+            yref='paper',
+            text=line_label,
+            showarrow=False,
+            font=dict(color=line_color),
+            xanchor='left',
+            yanchor='bottom'
+          )
 
   fig.update_layout(
     hovermode='x unified', height=300 * num_rows, title='Forecast values over time (by scenario)'

--- a/src/components/chart.py
+++ b/src/components/chart.py
@@ -172,7 +172,7 @@ def chart(control_values={}):
           )
 
   fig.update_layout(
-    hovermode='x unified', height=300 * num_rows, title='Forecast values over time (by scenario)'
+    hovermode='x unified', height=300 * num_rows, title='Forecast values over time (by scenario)', uirevision='df',
   )
   fig.update_xaxes(showspikes=True, spikemode='across', spikesnap='cursor')
   fig.update_yaxes(showspikes=True, spikemode='across')

--- a/src/components/viz_editor/controls/annotations_input.py
+++ b/src/components/viz_editor/controls/annotations_input.py
@@ -42,11 +42,17 @@ def color_picker_popover(index, value='#222222'):
           value=value,
           format='hex',
           swatches=[
-            '#222222', '#663399', '#993366', '#ff0000', '#00abc7', '#00ff00', '#ff9900',
+            '#222222',
+            '#663399',
+            '#993366',
+            '#ff0000',
+            '#00abc7',
+            '#00ff00',
+            '#ff9900',
           ],
           fullWidth=True,
         ),
-        style=dict(padding='0.5rem')
+        style=dict(padding='0.5rem'),
       ),
     ],
   )
@@ -130,7 +136,8 @@ def render_annotations(data):
       d.get('value'),
       d.get('label'),
       d.get('color'),
-    ) for index, d in enumerate(data)
+    )
+    for index, d in enumerate(data)
   ]
 
 
@@ -149,10 +156,10 @@ def manage_annotations(add_clicks, axes, values, labels, colors, delete_clicks, 
   stored = stored or []
 
   for i in range(len(stored)):
-    stored[i]["axis"] = axes[i]
-    stored[i]["label"] = labels[i]
-    stored[i]["color"] = colors[i]
-    stored[i]["value"] = values[i]
+    stored[i]['axis'] = axes[i]
+    stored[i]['label'] = labels[i]
+    stored[i]['color'] = colors[i]
+    stored[i]['value'] = values[i]
 
   trigger = ctx.triggered_id
 

--- a/src/components/viz_editor/controls/annotations_input.py
+++ b/src/components/viz_editor/controls/annotations_input.py
@@ -115,6 +115,7 @@ def annotations_input(value=[]):
     children=[
       dcc.Store(id='annotations-store', storage_type='memory', data=value),
       dmc.Text('Annotations', size='md'),
+      dmc.Divider(),
       dmc.Stack(
         id='annotations-container',
         children=[],

--- a/src/components/viz_editor/controls/annotations_input.py
+++ b/src/components/viz_editor/controls/annotations_input.py
@@ -15,22 +15,78 @@ def remove_annotation_button(index=0):
   return dmc.ActionIcon(
     DashIconify(icon='feather:trash-2', color='crimson'),
     variant='subtle',
-    size='lg',
+    # size='lg',
     id={'type': 'remove-annotation', 'index': index},
   )
 
 
-def annotation_row(index, label='', value=0, color='#222222'):
+def color_picker_popover(index, value='#222222'):
+  return dmc.Popover(
+    position='bottom-start',
+    withArrow=True,
+    trapFocus=True,
+    closeOnEscape=True,
+    closeOnClickOutside=True,
+    children=[
+      dmc.PopoverTarget(
+        dmc.ActionIcon(
+          DashIconify(icon='feather:droplet', color=value),
+          id={'type': 'color-button', 'index': index},
+          variant='light',
+          # size='lg',
+        )
+      ),
+      dmc.PopoverDropdown(
+        dmc.ColorPicker(
+          id={'type': 'color-value', 'index': index},
+          value=value,
+          format='hex',
+          swatches=[
+            '#222222', '#663399', '#993366', '#ff0000', '#00abc7', '#00ff00', '#ff9900',
+          ],
+          fullWidth=True,
+        ),
+        style=dict(padding='0.5rem')
+      ),
+    ],
+  )
+
+
+def annotation_row(index, axis, value=0, label='', color='#222222'):
+  axis_selector = dmc.Select(
+    data=[{'value': 'x', 'label': 'X'}, {'value': 'y', 'label': 'Y'}],
+    value=axis,
+    label='Axis',
+    id={'type': 'annotation-axis', 'index': index},
+    size='sm',
+    w=60,
+    allowDeselect=False,
+  )
+
+  # value input (date if x-axis, number if y-axis)
+  if axis == 'x':
+    value_input = dmc.DatePickerInput(
+      value=value,  # datetime.date or string like '2025-10-01'
+      label='Date',
+      placeholder='Pick a date',
+      id={'type': 'annotation-value', 'index': index},
+      size='sm',
+      w=145,
+    )
+  else:
+    value_input = dmc.NumberInput(
+      value=value,
+      label='Value',
+      placeholder='Enter y-value',
+      id={'type': 'annotation-value', 'index': index},
+      size='sm',
+      w=145,
+    )
+
   return dmc.Group(
     [
-      dmc.NumberInput(
-        value=value,
-        label='Value',
-        placeholder='Enter y-value',
-        id={'type': 'annotation-value', 'index': index},
-        size='sm',
-        w=85,
-      ),
+      axis_selector,
+      value_input,
       dmc.TextInput(
         value=label,
         label='Label',
@@ -39,12 +95,7 @@ def annotation_row(index, label='', value=0, color='#222222'):
         size='sm',
         style=dict(flex=1),
       ),
-      dmc.ColorInput(
-        id={'type': 'color-value', 'index': index},
-        value=color,
-        label='Color',
-        w=105,
-      ),
+      color_picker_popover(index=index, value=color),
       remove_annotation_button(index),
     ],
     gap='xs',
@@ -57,7 +108,7 @@ def annotations_input(value=[]):
     id='annotations-input',
     children=[
       dcc.Store(id='annotations-store', storage_type='memory', data=value),
-      dmc.Text('Annotations', size='sm'),
+      dmc.Text('Annotations', size='md'),
       dmc.Stack(
         id='annotations-container',
         children=[],
@@ -73,13 +124,20 @@ def render_annotations(data):
   if not data:
     return []
   return [
-    annotation_row(i, d.get('label'), d.get('value'), d.get('color')) for i, d in enumerate(data)
+    annotation_row(
+      index,
+      d.get('axis'),
+      d.get('value'),
+      d.get('label'),
+      d.get('color'),
+    ) for index, d in enumerate(data)
   ]
 
 
 @callback(
   Output('annotations-store', 'data'),
   Input('add-annotation-button', 'n_clicks'),
+  Input({'type': 'annotation-axis', 'index': ALL}, 'value'),
   Input({'type': 'annotation-value', 'index': ALL}, 'value'),
   Input({'type': 'annotation-label', 'index': ALL}, 'value'),
   Input({'type': 'color-value', 'index': ALL}, 'value'),
@@ -87,21 +145,20 @@ def render_annotations(data):
   State('annotations-store', 'data'),
   prevent_initial_call=True,
 )
-def manage_annotations(add_clicks, values, labels, colors, delete_clicks, stored):
+def manage_annotations(add_clicks, axes, values, labels, colors, delete_clicks, stored):
   stored = stored or []
 
-  # Update existing annotations from input fields
-  if values is not None and labels is not None and colors is not None:
-    for i in range(min(len(stored), len(values), len(colors))):
-      stored[i]['value'] = values[i]
-      stored[i]['label'] = labels[i]
-      stored[i]['color'] = colors[i]
+  for i in range(len(stored)):
+    stored[i]["axis"] = axes[i]
+    stored[i]["label"] = labels[i]
+    stored[i]["color"] = colors[i]
+    stored[i]["value"] = values[i]
 
   trigger = ctx.triggered_id
 
   # add new annotation
   if trigger == 'add-annotation-button':
-    stored.append(dict(value=None, label='', color='#00abc7'))
+    stored.append(dict(axis='y', value=None, label='', color='#00abc7'))
 
   # delete annotation
   elif isinstance(trigger, dict) and trigger.get('type') == 'remove-annotation':

--- a/src/data/rounds/round19/insights/seasonal-burden-and-trajectory.yaml
+++ b/src/data/rounds/round19/insights/seasonal-burden-and-trajectory.yaml
@@ -17,6 +17,11 @@ controls:
   scenarios: ['77', '78', '80']
   uncertainty: '95%'
   annotations:
-    - value: 17_000
-      label: "Some important value"
+    - axis: x
+      value: 2025-10-01
+      label: Some Policy change
+      color: "#993366"
+    - axis: y
+      value: 17_000
+      label: An important value
       color: "#663399"

--- a/src/data/rounds/round19/insights/vaccination-impact.yaml
+++ b/src/data/rounds/round19/insights/vaccination-impact.yaml
@@ -16,6 +16,7 @@ controls:
   scenarios: ['77', '78', '80']
   uncertainty: '95%'
   annotations:
-    - value: 19_000
-      label: "Some important value"
+    - axis: y
+      value: 19_000
+      label: "An important value"
       color: "#886622"


### PR DESCRIPTION
This PR introduces support for vertical annotations within the visualization editor. Vertical annotations are extracted from the insight YAML in the form

```yaml
controls:
  annotations:
    - axis: x
      value: 2025-10-31
      label: Halloween
      color: "#fc4c02"
    - axis: y
      value: 17_000
      label: A high value!
      color: "#663399"
```

On the other end, users can define annotations through the UI, which are then rendered on the chart in real time.

## Key Changes:
- YAML/data management
  - can read annotations (horiz and vert) from the insights YAML and populate the insight viewer and editor.
  - supports both numeric (y-axis) and date (x-axis) values.
- `annotations_row` component
  - added a control for axis selection
  - conditionally renders a numerical input or date picker based on `axis` value
  - improved color picker
- State management
  - updated `manage_annotations` callback to handle add/update/remove events.
  - zoom is maintained across control changes (with plotly's `uirevision`), which does also address #28 

## Next Steps / Potential Enhancements
  - Drag-to-reorder annotations in the list.
  - Line style selection
