### PR TITLE
Add Zoom Controls to the Visualization Editor

### DIFF
--- a/src/components/chart.py
+++ b/src/components/chart.py
@@ -7,13 +7,19 @@ from plotly.subplots import make_subplots
 
 
 def chart(control_values={}):
-  scenarios = [int(s) for s in control_values.get('scenarios', ['13'])]
+  scenarios = [int(s) for s in control_values.get('scenarios', ['77'])]
   models = [int(s) for s in control_values.get('models', [])]
   age_group = control_values.get('age_group', '0-130')
   location = control_values.get('location', 'US')
   target = control_values.get('target', 'incident_hospitalization')
   uncertainty = control_values.get('uncertainty', 'None')
   annotations = control_values.get('annotations', {})
+  zoom = control_values.get('zoom', {})
+
+  x_min = zoom.get('x', {}).get('min')
+  x_max = zoom.get('x', {}).get('max')
+  y_min = zoom.get('y', {}).get('min')
+  y_max = zoom.get('y', {}).get('max')
 
   path = build_dataset_path(round_number=19, location=location, target=target)
   df = pd.DataFrame(collect_data(path))
@@ -54,8 +60,6 @@ def chart(control_values={}):
     vertical_spacing=0.1,
     subplot_titles=[f'Scenario {s}' for s in scenarios],
   )
-  fig.update_xaxes(matches='x')
-  fig.update_yaxes(matches='y')
 
   for i, scenario in enumerate(scenarios, start=1):
     scenario_df = df[df['scenario_id'] == scenario]
@@ -134,10 +138,21 @@ def chart(control_values={}):
           annotation_font_color=line_color,
         )
 
-  fig.update_layout(
-    hovermode='x unified', height=300 * num_rows, title='Forecast values over time (by scenario)'
-  )
-  fig.update_xaxes(showspikes=True, spikemode='across', spikesnap='cursor')
-  fig.update_yaxes(showspikes=True, spikemode='across')
+  # updating axes
+  fig.update_xaxes(matches='x', showspikes=True, spikemode='across', spikesnap='cursor')
+  fig.update_yaxes(matches='y', showspikes=True, spikemode='across')
 
-  return dcc.Graph(figure=fig)
+  # and zoom ranges
+  if x_min is not None and x_max is not None:
+    fig.update_xaxes(range=[x_min, x_max])
+  if y_min is not None and y_max is not None:
+    fig.update_yaxes(range=[y_min, y_max])
+
+  fig.update_layout(
+    hovermode='x unified',
+    height=300 * num_rows,
+    title='Forecast values over time (by scenario)',
+    uirevision='df',
+  )
+
+  return dcc.Graph(figure=fig, id='chart-figure')

--- a/src/components/round_summary.py
+++ b/src/components/round_summary.py
@@ -271,7 +271,6 @@ def round_summary():
   Input('url', 'pathname'),
 )
 def update_round_summary(round_number, pathname):
-  print(dict(round_number=round_number, pathname=pathname))
   if not round_number:
     return 'No round selected', '...', []
   rounds = load_rounds()

--- a/src/components/save_insight_form.py
+++ b/src/components/save_insight_form.py
@@ -96,6 +96,7 @@ def toggle_form_visibility(reveal_clicks, hide_clicks, is_visible):
   State('age-group-select', 'value'),
   State('uncertainty-select', 'value'),
   State('ensemble-select', 'value'),
+  State('zoom-store', 'data'),
   State('annotations-store', 'data'),
   suppress_callback_exceptions=True,
 )
@@ -112,6 +113,7 @@ def save_custom_insight(
   age_group,
   uncertainty,
   ensemble,
+  zoom,
   annotations,
 ):
   if not n_clicks:
@@ -146,6 +148,7 @@ def save_custom_insight(
       age_group=age_group,
       uncertainty=uncertainty,
       ensemble=ensemble,
+      zoom=zoom,
       annotations=annotations,
     ),
   )

--- a/src/components/viz_editor/controls/annotations_input.py
+++ b/src/components/viz_editor/controls/annotations_input.py
@@ -57,7 +57,8 @@ def annotations_input(value=[]):
     id='annotations-input',
     children=[
       dcc.Store(id='annotations-store', storage_type='memory', data=value),
-      dmc.Text('Annotations', size='sm'),
+      dmc.Text('Annotations', size='md'),
+      dmc.Divider(),
       dmc.Stack(
         id='annotations-container',
         children=[],

--- a/src/components/viz_editor/controls/zoom_control.py
+++ b/src/components/viz_editor/controls/zoom_control.py
@@ -12,7 +12,13 @@ def zoom_control(value={}):
   return dmc.Stack(
     children=[
       dcc.Store(id='zoom-store', data=value),
-      dmc.Text('Zoom', size='md'),
+      dmc.Flex(
+        [
+          dmc.Text('Zoom', size='md'),
+          dmc.Button('Use chart zoom', id='use-chart-zoom-button', size='xs', variant='subtle'),
+        ],
+        justify='space-between',
+      ),
       dmc.Divider(),
       dmc.Flex(
         [

--- a/src/components/viz_editor/controls/zoom_control.py
+++ b/src/components/viz_editor/controls/zoom_control.py
@@ -1,0 +1,55 @@
+from dash import callback, ctx, dcc, exceptions, Input, Output, State
+import dash_mantine_components as dmc
+from dash_iconify import DashIconify
+
+
+def zoom_control(value={}):
+  x_min = value.get('x', {}).get('min')
+  x_max = value.get('x', {}).get('max')
+  y_min = value.get('y', {}).get('min')
+  y_max = value.get('y', {}).get('max')
+
+  return dmc.Stack(
+    children=[
+      dcc.Store(id='zoom-store', data=value),
+      dmc.Text('Zoom', size='md'),
+      dmc.Divider(),
+      dmc.Flex(
+        [
+          dmc.DateInput(id='zoom-x-min', label='X min', value=x_min),
+          dmc.DateInput(id='zoom-x-max', label='X max', value=x_max),
+          dmc.NumberInput(id='zoom-y-min', label='Y min', value=y_min, step=100),
+          dmc.NumberInput(id='zoom-y-max', label='Y max', value=y_max, step=100),
+        ],
+        gap='sm',
+      ),
+    ]
+  )
+
+
+@callback(
+  Output('zoom-store', 'data'),
+  Input('zoom-x-min', 'value'),
+  Input('zoom-x-max', 'value'),
+  Input('zoom-y-min', 'value'),
+  Input('zoom-y-max', 'value'),
+  State('zoom-store', 'data'),
+  prevent_initial_call=True,
+)
+def update_zoom(x_min, x_max, y_min, y_max, current_zoom):
+  zoom = current_zoom or {'x': {}, 'y': {}}
+  trigger = ctx.triggered_id
+
+  if trigger in ['zoom-x-min', 'zoom-x-max', 'zoom-y-min', 'zoom-y-max']:
+    zoom.setdefault('x', {})
+    zoom.setdefault('y', {})
+    if x_min is not None:
+      zoom['x']['min'] = x_min
+    if x_max is not None:
+      zoom['x']['max'] = x_max
+    if y_min is not None:
+      zoom['y']['min'] = y_min
+    if y_max is not None:
+      zoom['y']['max'] = y_max
+
+  return zoom

--- a/src/components/viz_editor/visualization_editor.py
+++ b/src/components/viz_editor/visualization_editor.py
@@ -1,4 +1,4 @@
-from dash import callback, html, Input, Output
+from dash import callback, dcc, exceptions, html, Input, Output, State
 import dash_mantine_components as dmc
 from .controls.scenarios_select import scenarios_select
 from .controls.location_select import location_select
@@ -63,7 +63,7 @@ def visualization_editor(control_values=None, show_controls=True):
   return dmc.Grid(
     children=[
       dmc.GridCol(
-        figure_container,
+        [dcc.Store('chart-extent-store'), figure_container],
         id='visualization-column',
         span=dict(base=12, xl=8, lg=7, md=8),
       ),
@@ -128,3 +128,37 @@ def update_chart(scenarios, models, location, target, age_group, uncertainty, zo
     annotations=annotations,
   )
   return chart(control_values=control_values)
+
+
+@callback(
+  Output('chart-extent-store', 'data'),
+  Input('chart-figure', 'relayoutData'),
+)
+def sync_zoom_store(relayout):
+  if not relayout:
+    raise exceptions.PreventUpdate
+  return dict(
+    x={'min': relayout.get('xaxis.range[0]'), 'max': relayout.get('xaxis.range[1]')},
+    y={'min': relayout.get('yaxis.range[0]'), 'max': relayout.get('yaxis.range[1]')},
+  )
+
+
+@callback(
+  Output('zoom-x-min', 'value'),
+  Output('zoom-x-max', 'value'),
+  Output('zoom-y-min', 'value'),
+  Output('zoom-y-max', 'value'),
+  Input('use-chart-zoom-button', 'n_clicks'),
+  State('chart-extent-store', 'data'),
+  prevent_initial_call=True,
+)
+def apply_current_zoom(n_clicks, current_zoom):
+  if not n_clicks or not current_zoom:
+    raise exceptions.PreventUpdate
+
+  return (
+    current_zoom['x'].get('min'),
+    current_zoom['x'].get('max'),
+    current_zoom['y'].get('min'),
+    current_zoom['y'].get('max'),
+  )

--- a/src/components/viz_editor/visualization_editor.py
+++ b/src/components/viz_editor/visualization_editor.py
@@ -7,6 +7,7 @@ from .controls.age_group_select import age_group_select
 from .controls.uncertainty_select import uncertainty_select
 from .controls.ensemble_select import ensemble_select
 from .controls.models_select import models_select
+from .controls.zoom_control import zoom_control
 from .controls.annotations_input import annotations_input
 from src.components.chart import chart
 
@@ -21,6 +22,7 @@ default_control_values = dict(
   age_group='0-130',
   uncertainty='None',
   ensemble='Ensemble',
+  zoom={},
   annotations={},
 )
 
@@ -35,6 +37,7 @@ def visualization_editor(control_values=None, show_controls=True):
   init_age_group = controls['age_group']
   init_uncertainty = controls['uncertainty']
   init_ensemble = controls['ensemble']
+  init_zoom = controls['zoom']
   init_annotations = controls['annotations']
 
   figure_control_values = dict(
@@ -45,6 +48,7 @@ def visualization_editor(control_values=None, show_controls=True):
     age_group=init_age_group,
     uncertainty=init_uncertainty,
     ensemble=init_ensemble,
+    zoom=init_zoom,
     annotations=init_annotations,
   )
 
@@ -61,72 +65,39 @@ def visualization_editor(control_values=None, show_controls=True):
       dmc.GridCol(
         figure_container,
         id='visualization-column',
-        span=7,
+        span=dict(base=12, xl=8, lg=7, md=8),
       ),
       dmc.GridCol(
         dmc.Stack(
           [
             dmc.Card(
-              dmc.Grid(
-                children=[
-                  dmc.GridCol(
-                    scenarios_select(value=init_scenarios),
-                    style=dict(padding='var(--mantine-spacing-sm)'),
-                    span=dict(base=12),
-                  ),
-                  dmc.GridCol(
-                    models_select(value=init_models),
-                    style=dict(padding='var(--mantine-spacing-sm)'),
-                    span=dict(base=12),
-                  ),
-                  dmc.GridCol(
-                    location_select(value=init_location),
-                    style=dict(padding='var(--mantine-spacing-sm)'),
-                    span=12,
-                  ),
-                  dmc.GridCol(
-                    target_select(value=init_target),
-                    style=dict(padding='var(--mantine-spacing-sm)'),
-                    span=12,
-                  ),
-                  dmc.GridCol(
-                    age_group_select(value=init_age_group),
-                    style=dict(padding='var(--mantine-spacing-sm)'),
-                    span=dict(base=12),
-                  ),
-                  dmc.GridCol(
-                    uncertainty_select(value=init_uncertainty),
-                    style=dict(padding='var(--mantine-spacing-sm)'),
-                    span=dict(base=12),
-                  ),
-                  dmc.GridCol(
-                    ensemble_select(value=init_ensemble),
-                    style=dict(padding='var(--mantine-spacing-sm)'),
-                    span=dict(base=12),
-                  ),
+              dmc.Stack(
+                [
+                  scenarios_select(value=init_scenarios),
+                  models_select(value=init_models),
+                  location_select(value=init_location),
+                  target_select(value=init_target),
+                  age_group_select(value=init_age_group),
+                  uncertainty_select(value=init_uncertainty),
+                  ensemble_select(value=init_ensemble),
                 ],
-                gutter=0,
+                gap='sm',
               ),
               variant='soft',
             ),
             dmc.Card(
-              dmc.Grid(
-                children=[
-                  dmc.GridCol(
-                    annotations_input(value=init_annotations),
-                    style=dict(padding='var(--mantine-spacing-sm)'),
-                    span=dict(base=12),
-                  ),
-                ],
-                gutter=0,
-              ),
+              zoom_control(value=init_zoom),
+              variant='soft',
+            ),
+            dmc.Card(
+              annotations_input(value=init_annotations),
               variant='soft',
             ),
           ],
           gap='md',
         ),
         id='controls-column',
-        span=5,
+        span=dict(base=12, xl=4, lg=5, md=4),
       ),
     ],
     mb=12,
@@ -141,10 +112,11 @@ def visualization_editor(control_values=None, show_controls=True):
   Input('target-select', 'value'),
   Input('age-group-select', 'value'),
   Input('uncertainty-select', 'value'),
+  Input('zoom-store', 'data'),
   Input('annotations-store', 'data'),
-  # prevent_initial_call=True,
+  prevent_initial_call=True,
 )
-def update_chart(scenarios, models, location, target, age_group, uncertainty, annotations):
+def update_chart(scenarios, models, location, target, age_group, uncertainty, zoom, annotations):
   control_values = dict(
     scenarios=scenarios,
     models=models,
@@ -152,6 +124,7 @@ def update_chart(scenarios, models, location, target, age_group, uncertainty, an
     target=target,
     age_group=age_group,
     uncertainty=uncertainty,
+    zoom=zoom,
     annotations=annotations,
   )
   return chart(control_values=control_values)

--- a/src/data/rounds/round19/insights/seasonal-burden-and-trajectory.yaml
+++ b/src/data/rounds/round19/insights/seasonal-burden-and-trajectory.yaml
@@ -16,6 +16,13 @@ controls:
   models: []
   scenarios: ['77', '78', '80']
   uncertainty: '95%'
+  zoom:
+    x:
+      min: 2025-01-01
+      max: 2026-06-30
+    y:
+      min: 0
+      max: 65_000
   annotations:
     - value: 17_000
       label: "Some important value"

--- a/src/pages/insight.py
+++ b/src/pages/insight.py
@@ -41,23 +41,29 @@ toolbar = dmc.Flex(
 
 loading_title = dmc.Skeleton(h=85)
 loading_chart = dmc.Skeleton(h=600)
-loading_description = dmc.Stack([
-  dmc.Skeleton(h=30),
-  dmc.Skeleton(h=30),
-  dmc.Skeleton(h=30),
-])
-loading_details = dmc.Stack([
-  loading_chart,
-  dmc.Space(h=24),
-  loading_description,
-])
+loading_description = dmc.Stack(
+  [
+    dmc.Skeleton(h=30),
+    dmc.Skeleton(h=30),
+    dmc.Skeleton(h=30),
+  ]
+)
+loading_details = dmc.Stack(
+  [
+    loading_chart,
+    dmc.Space(h=24),
+    loading_description,
+  ]
+)
 
 layout = dmc.Container(
   [
     toolbar,
     dmc.Title(id='insight-view-title', order=1, children=loading_title),
     dmc.Divider(my=24),
-    html.Div(id='insight-view-figure-container', style=dict(margin='24px 0'), children=loading_details),
+    html.Div(
+      id='insight-view-figure-container', style=dict(margin='24px 0'), children=loading_details
+    ),
     dcc.Markdown(id='insight-view-description'),
   ],
   size=1200,
@@ -81,19 +87,19 @@ def show_details(pathname, search, custom_insights):
     insight_id = get_query_param(search, 'id')
     if not insight_id:
       raise ValueError('No insight ID in URL')
-    
+
     insight = get_insight(insight_id, custom_insights=custom_insights or [])
     if not insight:
       raise ValueError(f'Insight {insight_id} not found')
-    
+
     controls = insight.get('controls', {})
-    
+
     return (
       visualization_editor(control_values=controls, show_controls=False),
       insight.get('title', 'Untitled Insight'),
       insight.get('description', ''),
     )
-    
+
   # fallback
   except Exception as e:
     return (


### PR DESCRIPTION
To address #15, this PR adds controls for setting a default chart zoom. Insight authors can define a default zoom window (viewport/extent) for the graphs. The “Reset Axes” Plotly toolbar button will reset the chart to this user-defined zoom.

## Notes/known issues/future enhancements

- When creating a new insight in the Explorer, the zoom input fields start blank. Ideally, these controls would be pre-filled with the extent of the underlying data. Having a sensible default zoom in place streamlines the insight authoring experience.
- The "Autoscale" button in the Plotly toolbar expands to show all the underlying data--going back several years, due to the Gold Standard data. 