### PR TITLE
Implement round names

### DIFF
--- a/assets/round-select.css
+++ b/assets/round-select.css
@@ -1,18 +1,35 @@
 .mantine-Select-dropdown {
-  height: min-content;
-}
+  --option-accent-color: var(--mantine-primary-color-filled);
+  --option-hover-accent-color: color-mix(
+    in oklab,
+    var(--mantine-primary-color-filled) 75%,
+    var(--mantine-color-gray-6) 25%
+  );
+  --option-bg-color: light-dark(var(--mantine-color-white), var(--mantine-color-dark-6));
+  --option-hover-bg-color: color-mix(in hsl, var(--option-bg-color), #999 10%);
 
-.mantine-Select-option:has(.round-option) {
+  height: min-content;
   padding: 0;
+  border: 0;
+  background-color: color-mix(in hsl, var(--option-bg-color), transparent 20%); /* kinda see-thru dropdown tray */
+  backdrop-filter: blur(3px); /* with glass effect  */
+  .mantine-ScrollArea-content {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
 }
 
 .round-option {
+  margin: 8px;
   width: 100%;
   display: flex;
-  align-items: space-between;
   padding: 1rem;
   border-radius: 4px;
   position: relative;
+  background-color: var(--option-bg-color);
+  border: 1px solid var(--mantine-color-gray-filled);
+  transition: background-color 120ms ease, border-color 120ms ease, color 120ms ease;
   .round-option-label {
     font-weight: bold;
   }
@@ -28,7 +45,8 @@
     background-color: var(--mantine-color-gray-filled);
   }
   &.selected {
-    background-color: color-mix(in hsl, var(--mantine-primary-color-filled) 5%, transparent);
+    background-color: var(--option-hover-bg-color);
+    border: 1px solid var(--mantine-primary-color-filled);
     .round-option-label {
       color: var(--mantine-primary-color-filled);
     }
@@ -37,3 +55,18 @@
     background-color: var(--mantine-primary-color-filled);
   }
 }
+
+.mantine-Select-option {
+  padding: 0;
+  background-color: transparent;
+  &:hover {
+    background-color: transparent;
+  }  
+  &:not([data-combobox-active="true"]):hover .round-option {
+    background-color: var(--option-hover-bg-color);
+    /*border: 1px solid var(--option-hover-accent-color);*/
+    &::before {
+      background-color: var(--option-hover-accent-color);
+    }
+  }
+}  

--- a/src/components/round_select.py
+++ b/src/components/round_select.py
@@ -28,6 +28,7 @@ def round_select(value='19'):
     allowDeselect=False,
     renderOption={'function': 'renderRoundOption'},
     style=dict(width='300px'),
+    withScrollArea=False,
   )
 
 

--- a/src/components/round_select.py
+++ b/src/components/round_select.py
@@ -1,30 +1,21 @@
-import random
 from dash import callback, Input, Output
 import dash_mantine_components as dmc
 from ..util.data import load_rounds
 
 rounds = load_rounds()
 
-# temp, for round option blurbs
-lorem_ispum = [
-  'Aliquip ex dolor aliqua sed est ea minim aute in dolor.',
-  'Officia incididunt cillum eu minim excepteur proident.',
-  'Ullamco aliquip reprehenderit ea proident proident aliquip.',
-  'Lorem ipsum quis consectetur deserunt ad quis tempor cupidatat.',
-  'Nostrud ut occaecat incididunt sed nulla nostrud est in.',
-]
-
 options = [
   dict(
     value=n,
+    round_number=rounds[n]['round_number'],
     label=f'Round {rounds[n]["round_number"]}',
-    snippet=random.choice(lorem_ispum),
+    snippet=rounds[n]['name'],
     insights_count=len(rounds[n].get('insights')),
   )
   for n in rounds.keys()
 ]
 
-sorted_options = sorted(options, key=lambda o: o['label'], reverse=True)
+sorted_options = sorted(options, key=lambda o: o['round_number'], reverse=True)
 
 
 def round_select(value='19'):

--- a/src/data/rounds/round18/details.yaml
+++ b/src/data/rounds/round18/details.yaml
@@ -1,5 +1,5 @@
 round_number: 18
-name: "Round 18"
+name: "Not a real round"
 report: >
   ## Executive Summary Report
 

--- a/src/data/rounds/round19/details.yaml
+++ b/src/data/rounds/round19/details.yaml
@@ -1,5 +1,5 @@
 round_number: 19
-name: "Round 19"
+name: "Vaccine Recommendation Levels"
 report: >
   ## Executive Summary Report
 

--- a/src/util/data.py
+++ b/src/util/data.py
@@ -89,32 +89,9 @@ def load_rounds():
 
     rounds[round_number] = dict(
       round_number=int(round_number),
-      name=f'Round {round_number}',
+      name=details.get('name'),
       report=details.get('report', ''),
       insights=insights,
     )
 
   return rounds
-
-  # rounds = {}
-  # for round_dir in sorted(os.listdir(ROUNDS_DIR)):
-  #   full_path = os.path.join(ROUNDS_DIR, round_dir)
-  #   if not os.path.isdir(full_path) or not round_dir.lower().startswith('round'):
-  #     continue
-
-  #   # reduce key to just the number
-  #   round_num = round_dir.lower().replace('round', '')
-
-  #   insights = []
-  #   for filename in sorted(os.listdir(full_path)):
-  #     if filename.endswith('.yaml'):
-  #       path = os.path.join(full_path, filename)
-  #       with open(path, 'r') as f:
-  #         insight = yaml.safe_load(f)
-  #         insight['type'] = 'system'
-  #         insights.append(insight)
-
-  #   insights.sort(key=lambda x: x.get('title', '').lower())
-  #   rounds[round_num] = insights
-
-  # return rounds


### PR DESCRIPTION
To address, #34 the `snippet` property of the round options is pulling from the round name specified in the round details.yaml

<img width="287" height="252" alt="image" src="https://github.com/user-attachments/assets/204922bf-4cda-4f02-aa3c-5228924fb641" />

<img width="435" height="299" alt="image" src="https://github.com/user-attachments/assets/0852c86e-38f9-4a55-9d80-e1f21f0fd390" />