### PR TITLE
Fix React key warning in custom round option renderer

### DIFF
--- a/assets/js/render_round_option.js
+++ b/assets/js/render_round_option.js
@@ -10,8 +10,8 @@
       dmc.Stack,
       { className: `round-option ${ checked ? 'selected' : 'unselected' }` },
       React.createElement(dmc.Group, { justify: 'space-between' }, [
-        React.createElement(dmc.Text, { size: 'md', className: 'round-option-label' }, option.label),
-        React.createElement(dmc.Text, { size: 'xs' }, `${ option.insights_count } insights`)
+        React.createElement(dmc.Text, { key: 'label', size: 'md', className: 'round-option-label' }, option.label),
+        React.createElement(dmc.Text, { key: 'count', size: 'xs' }, `${ option.insights_count } insights`)
       ]),
       React.createElement(dmc.Text, { size: 'sm' }, option.snippet),
     );


### PR DESCRIPTION
Addressing #37, this PR adds `key` props to the child elements inside the `dmc.Group` returned by the `renderRoundOption` clientside callback function so React can properly reconcile the elements during re-renders.