### PR TITLE
Fix TypeError by using milliseconds since epoch

### DIFF
--- a/src/components/chart.py
+++ b/src/components/chart.py
@@ -312,9 +312,7 @@ class Chart:
       str(controls.zoom.x.max if controls.zoom.x.max else ''),
       str(controls.zoom.y.min if controls.zoom.y.min else ''),
       str(controls.zoom.y.max if controls.zoom.y.max else ''),
-      str(
-        sorted([a.get_key() for a in controls.annotations]) if controls.annotations else []
-      ),
+      str(sorted([a.get_key() for a in controls.annotations]) if controls.annotations else []),
     ]
     # Use a deterministic string key
     return '|'.join(key_components)
@@ -610,7 +608,7 @@ class Chart:
     for annotation in self.controls.annotations:
       if isinstance(annotation, HorizontalAnnotation):
         self._fig.add_hline(
-          y=annotation.value,
+          y=annotation.value or 0,
           line_dash='dot',
           line_color=annotation.color,
           line_width=1,
@@ -620,7 +618,11 @@ class Chart:
         # Convert date to timestamp in milliseconds, as there passing the datetime object directly and adding annotation_text causes a TypeError
         # See: https://github.com/plotly/plotly.py/issues/3065
         # Assuming date is in "YYYY-MM-DD" format
-        ms = datetime.strptime(annotation.value, "%Y-%m-%d").timestamp() * 1000
+        ms = (
+          datetime.strptime(annotation.value, '%Y-%m-%d').timestamp() * 1000
+          if annotation.value
+          else None
+        )
 
         self._fig.add_vline(
           x=ms,

--- a/src/components/chart.py
+++ b/src/components/chart.py
@@ -617,8 +617,13 @@ class Chart:
           annotation_text=annotation.label,
         )
       elif isinstance(annotation, VerticalAnnotation):
+        # Convert date to timestamp in milliseconds, as there passing the datetime object directly and adding annotation_text causes a TypeError
+        # See: https://github.com/plotly/plotly.py/issues/3065
+        # Assuming date is in "YYYY-MM-DD" format
+        ms = datetime.strptime(annotation.value, "%Y-%m-%d").timestamp() * 1000
+
         self._fig.add_vline(
-          x=annotation.value,
+          x=ms,
           line_dash='dot',
           line_color=annotation.color,
           line_width=1,

--- a/src/components/viz_editor/controls/annotations_input.py
+++ b/src/components/viz_editor/controls/annotations_input.py
@@ -181,11 +181,14 @@ def update_annotations(
     return stored
 
   # update stored annotations
-  for i in range(len(stored)):
-    stored[i]['type'] = types[i]
-    stored[i]['value'] = values[i]
-    stored[i]['label'] = labels[i]
-    stored[i]['color'] = colors[i]
+  if stored:
+    for i in range(len(stored)):
+      stored[i]['type'] = types[i]
+      stored[i]['value'] = values[i]
+      stored[i]['label'] = labels[i]
+      stored[i]['color'] = colors[i]
+  else:
+    stored = []
 
   # add new annotation
   if trigger == 'add-annotation-button':


### PR DESCRIPTION
Looks like there is a plotly bug when passing a label to a time axis with add_vline: add_vline

Fixed by converting date to milliseconds since epoch using datetime.strptime. Assumes date in "YYYY-MM-DD" format.