### PR TITLE
Add methods in scroll area near bottom of page

### DIFF
--- a/src/components/disclaimer.py
+++ b/src/components/disclaimer.py
@@ -5,7 +5,7 @@ disclaimer = dcc.Markdown(
     The US COVID-19 Scenario Modeling Hub aims to produce robust projections to provide real-time actionable modeling
     evidence to support ongoing public health needs and decision-making. For Round 19, eight teams contributed both national
     and state-specific projections of the trajectory of COVID-19 during April 27, 2025 to April 25, 2026. Detailed scenario
-    descriptions and setting assumptions are provided on the SMH GitHub site. See covid19scenariomodelinghub.org for more
+    descriptions and setting assumptions are provided on the SMH GitHub site. See [covid19scenariomodelinghub.org](https://covid19scenariomodelinghub.org) for more
     results and details.
   """,
   style=dict(color='gray'),

--- a/src/components/round_summary.py
+++ b/src/components/round_summary.py
@@ -297,6 +297,8 @@ def round_summary():
       dmc.Title('Custom Insights', order=2, my=16),
       dmc.Stack(id='custom-insights-list', gap='md'),
       dcc.Download(id='round-pdf-download'),
+      dmc.Title('Methods', order=2, my=16),
+      dmc.ScrollArea(id='round-methods', h=250),
     ],
     gap='md',
   )
@@ -306,6 +308,7 @@ def round_summary():
   Output('round-title', 'children'),
   Output('round-overview', 'children'),
   Output('insights-list', 'children'),
+  Output('round-methods', 'children'),
   Input('selected-round-store', 'data'),
   Input('url', 'pathname'),
 )
@@ -319,7 +322,8 @@ def update_round_summary(round_number, pathname):
 
   report = this_round.get('report') or '...'
   insights = this_round.get('insights') or []
-  return f'Round {round_number}', dcc.Markdown(report), [insight_button(i) for i in insights]
+  methods = this_round.get('methods') or '...'
+  return f'Round {round_number}', dcc.Markdown(report), [insight_button(i) for i in insights], dcc.Markdown(methods)
 
 
 @callback(

--- a/src/data/rounds/round19/details.yaml
+++ b/src/data/rounds/round19/details.yaml
@@ -10,3 +10,26 @@ report: >
     over 65 years and those under 65 years with high-risk conditions; and
     iii. universal recommendation for all eligible age groups, each with uptake
     corresponding to 2024-25 coverage levels.
+methods: |
+  ### Ensemble methods
+  Currently, the Scenario Modeling Hub ensembles individual projections using two methods (both not available for early rounds):
+  - **Ensemble_LOP** is calculated by averaging cumulative probabilities of a given value across weighted submissions. At each value, the highest and lowest probability is removed before averaging.
+  - **Ensemble_LOP_untrimmed** is calculated by averaging cumulative probabilities of a given value across weighted submissions. All values are included in the average.
+  - **Ensemble** is obtained by calculating the weighted median of each submitted quantile.
+
+  Ensembles projection include only those submissions that reported all quantiles and the four scenarios for their targets. Individual model and ensemble projections are available in the [GitHub Repository](https://github.com/midas-network/covid19-scenario-modeling-hub).
+
+  ### Projection truncation (Round 3 to round 6): 
+  Since models were not required to incorporate behavioral feedbacks that would likely accompany large increases in COVID-19 cases, hospitalizations, or deaths, we truncate projected values beyond 80% of previously seen peaks. Within each location, truncation is evaluated separately for incident cases and deaths.
+  The truncation threshold is calculated as 80% of the highest observed weekly incidence, adjusted by population size. Once either threshold is crossed, all projections (incident and cumulative case, death, and hospitalization) are truncated using following the following rules:
+  - If an individual model projects incident cases or deaths to be higher than the threshold, median projections are not plotted for that model beyond the week at which the threshold is crossed. Uncertainty intervals are retained for all weeks. This truncation is applied to all states, except those for which truncation would remove all projection points.
+  - If the Ensemble crosses the threshold, no projections (median or uncertainty intervals) are plotted beyond the first week at which the threshold is crossed.
+
+  ### Ground Truth data
+  The model projections for cumulative hospitalizations start at zero, so no observed data are shown. Starting round 17, same principle will be applied for cumulative death.
+
+  ### Licensing
+  Models projection are available by default under a CC BY 4.0 license. Some models have specific license. See repository for details.
+
+  ### Disclaimer
+  The content of the COVID-19 Scenario Modeling Hub is solely the responsibility of the participating teams and the Hub maintainers and does not represent the official views of any related funding organizations.

--- a/src/util/data.py
+++ b/src/util/data.py
@@ -50,6 +50,7 @@ def load_rounds():
       name=details.get('name'),
       report=details.get('report', ''),
       insights=insights,
+      methods=details.get('methods', ''),
     )
 
   return rounds


### PR DESCRIPTION
Add a methods section in a scroll area near the bottom of the page. Methods text was taken from the Covid19 SHM Notes: [https://covid19scenariomodelinghub.org/viz.html](https://covid19scenariomodelinghub.org/viz.html). 

Methods are provided as markdown in details.yaml per round.