### PR TITLE
Explorer layout breakpoints

### DIFF
--- a/src/components/viz_editor/controls/zoom_control.py
+++ b/src/components/viz_editor/controls/zoom_control.py
@@ -25,14 +25,13 @@ def zoom_control(value=None):
         justify='space-between',
       ),
       dmc.Divider(),
-      dmc.Flex(
+      dmc.Grid(
         [
-          dmc.DateInput(id='zoom-x-min', label='X min', value=x_min),
-          dmc.DateInput(id='zoom-x-max', label='X max', value=x_max),
-          dmc.NumberInput(id='zoom-y-min', label='Y min', value=y_min, step=100),
-          dmc.NumberInput(id='zoom-y-max', label='Y max', value=y_max, step=100),
+          dmc.GridCol(dmc.DateInput(id='zoom-x-min', label='X min', value=x_min), span=dict(base=12, md=6, sm=6)),
+          dmc.GridCol(dmc.DateInput(id='zoom-x-max', label='X max', value=x_max), span=dict(base=12, md=6, sm=6)),
+          dmc.GridCol(dmc.NumberInput(id='zoom-y-min', label='Y min', value=y_min, step=100), span=dict(base=12, md=6, sm=6)),
+          dmc.GridCol(dmc.NumberInput(id='zoom-y-max', label='Y max', value=y_max, step=100), span=dict(base=12, md=6, sm=6)),
         ],
-        gap='sm',
       ),
     ]
   )

--- a/src/components/viz_editor/visualization_editor.py
+++ b/src/components/viz_editor/visualization_editor.py
@@ -75,23 +75,22 @@ def visualization_editor(control_values=None, show_controls=True):
       dmc.GridCol(
         [dcc.Store('chart-extent-store'), figure_container],
         id='visualization-column',
-        span=dict(base=12, xl=8, lg=7, md=8),
+        span=dict(base=12, xl=8, lg=7),
         style={'display': 'flex', 'flexDirection': 'column'},
       ),
       dmc.GridCol(
         dmc.Stack(
           [
             dmc.Card(
-              dmc.Stack(
+              dmc.Grid(
                 [
-                  scenarios_select(value=init_scenarios),
-                  models_select(value=init_models),
-                  location_select(value=init_location),
-                  target_select(value=init_target),
-                  age_group_select(value=init_age_group),
-                  certainty_select(value=init_certainty),
+                  dmc.GridCol(scenarios_select(value=init_scenarios), span=dict(base=12)),
+                  dmc.GridCol(models_select(value=init_models), span=dict(base=12)),
+                  dmc.GridCol(location_select(value=init_location), span=dict(base=12, sm=6)),
+                  dmc.GridCol(target_select(value=init_target), span=dict(base=12, sm=6)),
+                  dmc.GridCol(age_group_select(value=init_age_group), span=dict(base=12, sm=6)),
+                  dmc.GridCol(certainty_select(value=init_certainty), span=dict(base=12, sm=6)),
                 ],
-                gap='sm',
               ),
               variant='soft',
             ),
@@ -107,7 +106,7 @@ def visualization_editor(control_values=None, show_controls=True):
           gap='md',
         ),
         id='controls-column',
-        span=dict(base=12, xl=4, lg=5, md=4),
+        span=dict(base=12, xl=4, lg=5),
       ),
     ],
     mb=12,

--- a/src/components/viz_editor/visualization_editor.py
+++ b/src/components/viz_editor/visualization_editor.py
@@ -75,7 +75,7 @@ def visualization_editor(control_values=None, show_controls=True):
       dmc.GridCol(
         [dcc.Store('chart-extent-store'), figure_container],
         id='visualization-column',
-        span=dict(base=12, xl=8, lg=7),
+        span=dict(base=12, xl=8),
         style={'display': 'flex', 'flexDirection': 'column'},
       ),
       dmc.GridCol(
@@ -106,7 +106,7 @@ def visualization_editor(control_values=None, show_controls=True):
           gap='md',
         ),
         id='controls-column',
-        span=dict(base=12, xl=4, lg=5),
+        span=dict(base=12, xl=4),
       ),
     ],
     mb=12,


### PR DESCRIPTION
This PR addresses and merging will close #60.

The Explorer view now switches from a two-column layout to a single-column layout at large display widths (>1200px). Previously, this breakpoint was set at medium display widths (>992px).

Additionally, the internal grid structure within control components is improved.