### PR TITLE
Bugfix/whitespace click

### DIFF
--- a/assets/visualization-listener.js
+++ b/assets/visualization-listener.js
@@ -1,0 +1,28 @@
+function cancelEvent(evt) {
+  evt.stopPropagation();
+  return false;
+}
+
+(function(){
+  const id = 'insight-visualization-figure';
+
+  function attachIfReady(){
+    const el = document.getElementById(id);
+    if (el) {
+      // Using a named function will only add the listener once
+      el.addEventListener('click', cancelEvent);
+      return true;
+    }
+    
+    return false;
+  }
+
+  if (!attachIfReady()) {
+    // watch the DOM and attach as soon as the element appears
+    const mo = new MutationObserver((mutations, obs) => {
+      // Cancelling observer when true doesn't seem to work, so we just check each time
+      attachIfReady();
+    });
+    mo.observe(document.body, { childList: true, subtree: true });
+  }
+})();

--- a/src/components/chart.py
+++ b/src/components/chart.py
@@ -436,7 +436,7 @@ class Chart:
     return self._fig
 
   def get_graph(self) -> dcc.Graph:
-    return dcc.Graph(id='graph', figure=self._fig)
+    return dcc.Graph(id='my-graph', figure=self._fig)
 
   def get_raw_dataframe(self) -> pd.DataFrame:
     return self._raw_df
@@ -482,28 +482,24 @@ class Chart:
     """
     self.controls.round_num = round_num
     self._reload_data()
-    self.refresh_fig()
 
   def update_pathogen(self, pathogen: str) -> None:
     """
     Update the pathogen name.
     """
     self.controls.pathogen = pathogen
-    self.refresh_fig()
 
   def update_scenarios(self, scenario_names: list[str]) -> None:
     """
     Update the scenarios list.
     """
     self.controls.scenarios = [Scenario(name=scenario_name) for scenario_name in scenario_names]
-    self.refresh_fig()
 
   def update_models(self, model_names: list[str]) -> None:
     """
     Update the models list.
     """
     self.controls.models = [Model(model_name) for model_name in model_names]
-    self.refresh_fig()
 
   def update_location(self, location_name: str) -> None:
     """
@@ -511,7 +507,6 @@ class Chart:
     """
     self.controls.location = Location(location_name)
     self._reload_data()
-    self.refresh_fig()
 
   def update_target(self, target: str) -> None:
     """
@@ -519,14 +514,12 @@ class Chart:
     """
     self.controls.target = Target.from_input_value(target)
     self._reload_data()
-    self.refresh_fig()
 
   def update_age_group(self, age_group: str) -> None:
     """
     Update the age group.
     """
     self.controls.age_group = AgeGroup.from_input_value(age_group)
-    self.refresh_fig()
 
   def update_annotations(self, annotations: list[dict[str, Any]] | None) -> None:
     """
@@ -535,7 +528,6 @@ class Chart:
     self.controls.annotations = (
       [Annotation.from_dict(annotation) for annotation in annotations] if annotations else None
     )
-    self.refresh_fig()
 
   def update_certainty_percent(self, certainty_percent: str | None) -> None:
     """
@@ -544,14 +536,12 @@ class Chart:
     self.controls.certainty_percent = (
       CertaintyInterval.from_display_value(certainty_percent) if certainty_percent else None
     )
-    self.refresh_fig()
 
   def update_zoom(self, zoom: dict[str, dict[str, Any]] | None) -> None:
     """
     Update the zoom settings.
     """
     self.controls.zoom = Zoom(zoom['x'], zoom['y']) if zoom else Zoom()
-    self.refresh_fig()
 
   def _plot_certainty_interval(
     self, scenario_df: pd.DataFrame, model: Model, row_num: int


### PR DESCRIPTION
This bugfix is for #50 . I looked into a few things, including:

chart.py:
- Different values for uirevision in self._fig.update_layout()
- Adding and trying different values for datarevision in self._fig.update_layout()
- Creating a dcc.Graph member variable and returning that instead of creating new one each call to get_graph

Not of that seemed to do anything. 

I then tried adding an event listener to the insight-visualization-figure using the console in chrome, and calling stopPropagation. That worked! 

However calling js code from Dash is a bit tricky. I was able to get it working by using a client_callback listening to the n_clicks property on the insight-visualization-figure, and then adding the appropriate eventListener, however that required you to perform an initial click in the whitespace to attache the eventListener. I tried a few other ways to attach it, including:
- Using html.Script
- Using @callback listening to some properties on the dmc.Grid, such as children and id

However none of those worked. I then added the visualization-listener.js script to the assets folder, and that works. However, it is using a mutation observer to check for changes in the dom and then add the eventlistener, so it is not the cleanest solution as it fires a whole bunch. 

In fact, I think using stopPropagation at all is a hack, as there is something else going on that is causing the state to revert for the visualization on the click. However, for now I think this should do.

In the future we could try finding some other ways to add the eventListener right when the figure is loaded, or make a deeper dive into the underlying problem.

I also noticed that refresh_fig was getting called twice for each UI update, so removed calls other than for update_controls.