### PR TITLE
Surface round name in round summary

### DIFF
--- a/assets/js/render_round_option.js
+++ b/assets/js/render_round_option.js
@@ -14,6 +14,7 @@
         React.createElement(dmc.Text, { key: 'count', size: 'xs' }, `${ option.insights_count } insights`)
       ]),
       React.createElement(dmc.Text, { size: 'sm' }, option.snippet),
+      React.createElement(dmc.Text, { key: 'label', size: 'sm', c: 'dimmed', className: 'round-option-sublabel' }, option.sublabel),
     );
   };
 })();

--- a/assets/round-select.css
+++ b/assets/round-select.css
@@ -29,6 +29,10 @@
   .round-option-label {
     font-weight: bold;
   }
+  .round-option-sublabel {
+    font-weight: normal;
+    font-style: italic;
+  }
   &::before {
     content: "";
     position: absolute;

--- a/src/components/round_select.py
+++ b/src/components/round_select.py
@@ -10,6 +10,7 @@ options = [
     value=n,
     round_number=rounds[n]['round_number'],
     label=f'Round {rounds[n]["round_number"]}',
+    sublabel=f'Round completed: {rounds[n]["date"]}',
     snippet=rounds[n]['name'],
     insights_count=len(rounds[n].get('insights')),
   )

--- a/src/components/round_summary.py
+++ b/src/components/round_summary.py
@@ -16,6 +16,7 @@ from dash import (
 from dash_iconify import DashIconify
 
 from src.components.tooltip import tooltip
+from src.components.toolbar import toolbar
 from src.util.data import load_rounds
 from src.util.export.pdf import generate_round_pdf
 from src.util.format_timestamp import format_timestamp
@@ -286,12 +287,9 @@ def round_heading(number: str, date: str, name: str):
     ], justify='space-between', align='flex-end'),
   ], gap=0)
 
-round_toolbar = dmc.Card([
-  dmc.Flex(
-    dmc.Flex([download_button], gap='xs'),
-    justify='flex-end',
-    align='center',
-  )], variant='soft', p='xs', mb=24)
+round_toolbar = toolbar(
+  right=[download_button]
+)
 
 
 def round_summary():
@@ -311,7 +309,7 @@ def round_summary():
       dmc.Title('Methods', order=3, my=16),
       dmc.ScrollArea(id='round-methods', h=250),
     ],
-    gap='md',
+    gap=0,
   )
 
 

--- a/src/components/round_summary.py
+++ b/src/components/round_summary.py
@@ -44,9 +44,8 @@ no_insights_message = dmc.Card(
           dmc.Button(
             [
               'Build a custom insight',
-              ' ',
-              DashIconify(icon='feather:arrow-right', width=20),
             ],
+            leftSection=DashIconify(icon='feather:arrow-up-right', width=20),
             variant='gradient',
             gradient={'from': 'lime', 'to': 'teal', 'deg': 120},
             style=dict(
@@ -112,7 +111,8 @@ def insight_button(item):
 
   view_button = dmc.Anchor(
     dmc.Button(
-      ['View', ' ', DashIconify(icon='feather:arrow-right', width=20)],
+      'View',
+      rightSection=DashIconify(icon='feather:arrow-right', width=20),
       variant='light',
       style=dict(
         textDecoration='none',
@@ -268,36 +268,40 @@ delete_modal = dmc.Modal(
   centered=True,
 )
 
-download_button = dmc.ActionIcon(
-  DashIconify(icon='feather:download'),
+download_button = dmc.Button(
+  'PDF',
+  leftSection=DashIconify(icon='feather:download'),
   id='download-round-button',
-  variant='subtle',
-  size='lg',
+  variant='light',
+  size='xs',
   loading=False,
 )
 
 def round_heading(number: str, date: str, name: str):
   return dmc.Stack([
     dmc.Title(f'Round {number}', order=1, style=dict(fontSize='var(--mantine-h2-font-size'), c='dimmed'),
-    dmc.Title(name, order=2, style=dict(fontSize='var(--mantine-h1-font-size')),
-    dmc.Text(f'Date completed: {date}', c='dimmed', style=dict(fontStyle='italic')),
+    dmc.Flex([
+      dmc.Text(name, style=dict(fontSize='var(--mantine-h1-font-size'), fw=700),
+      dmc.Text(f'Date completed: {date}', c='dimmed', span=True, style=dict(fontStyle='italic')),
+    ], justify='space-between', align='flex-end'),
   ], gap=0)
+
+round_toolbar = dmc.Card([
+  dmc.Flex(
+    dmc.Flex([download_button], gap='xs'),
+    justify='flex-end',
+    align='center',
+  )], variant='soft', p='xs', mb=24)
 
 
 def round_summary():
   return dmc.Stack(
     [
       delete_modal,
-      dmc.Space(h=24),
-      dmc.Flex(
-        [
-          dmc.Box(id='round-heading'),
-          tooltip(download_button, label='Download PDF'),
-        ],
-        justify='space-between',
-        align='flex-end',
-      ),
-      dmc.Divider(),
+      dmc.Space(h=16),
+      dmc.Box(id='round-heading'),
+      round_toolbar,
+      dmc.Title('Round Summary', order=3),
       dmc.Box(id='round-overview'),
       dmc.Title('Insights from the Modeling Hub', order=3, my=16),
       dmc.Stack(id='insights-list', gap='md'),

--- a/src/components/round_summary.py
+++ b/src/components/round_summary.py
@@ -276,6 +276,13 @@ download_button = dmc.ActionIcon(
   loading=False,
 )
 
+def round_heading(round_number: str, round_name: str):
+  print(dict(round_number=round_number))
+  return dmc.Stack([
+    dmc.Title(f'Round {round_number}', order=1, style=dict(fontSize='var(--mantine-h2-font-size'), c='dimmed'),
+    dmc.Title(round_name, order=2, style=dict(fontSize='var(--mantine-h1-font-size')),
+  ], gap=0)
+
 
 def round_summary():
   return dmc.Stack(
@@ -284,7 +291,7 @@ def round_summary():
       dmc.Space(h=24),
       dmc.Flex(
         [
-          dmc.Title(id='round-title', order=1),
+          dmc.Box(id='round-heading'),
           tooltip(download_button, label='Download PDF'),
         ],
         justify='space-between',
@@ -292,12 +299,12 @@ def round_summary():
       ),
       dmc.Divider(),
       dmc.Box(id='round-overview'),
-      dmc.Title('Insights from the Modeling Hub', order=2, my=16),
+      dmc.Title('Insights from the Modeling Hub', order=3, my=16),
       dmc.Stack(id='insights-list', gap='md'),
-      dmc.Title('Custom Insights', order=2, my=16),
+      dmc.Title('Custom Insights', order=3, my=16),
       dmc.Stack(id='custom-insights-list', gap='md'),
       dcc.Download(id='round-pdf-download'),
-      dmc.Title('Methods', order=2, my=16),
+      dmc.Title('Methods', order=3, my=16),
       dmc.ScrollArea(id='round-methods', h=250),
     ],
     gap='md',
@@ -305,7 +312,7 @@ def round_summary():
 
 
 @callback(
-  Output('round-title', 'children'),
+  Output('round-heading', 'children'),
   Output('round-overview', 'children'),
   Output('insights-list', 'children'),
   Output('round-methods', 'children'),
@@ -320,11 +327,13 @@ def update_round_summary(round_number, pathname):
   if not this_round:
     return f'Round {round_number}', 'No data.', []
 
+  round_name = this_round.get('name')
+
   report = this_round.get('report') or '...'
   insights = this_round.get('insights') or []
   methods = this_round.get('methods') or '...'
   return (
-    f'Round {round_number}',
+    round_heading(round_number, round_name),
     dcc.Markdown(report),
     [insight_button(i) for i in insights],
     dcc.Markdown(methods),

--- a/src/components/round_summary.py
+++ b/src/components/round_summary.py
@@ -276,11 +276,11 @@ download_button = dmc.ActionIcon(
   loading=False,
 )
 
-def round_heading(round_number: str, round_name: str):
-  print(dict(round_number=round_number))
+def round_heading(number: str, date: str, name: str):
   return dmc.Stack([
-    dmc.Title(f'Round {round_number}', order=1, style=dict(fontSize='var(--mantine-h2-font-size'), c='dimmed'),
-    dmc.Title(round_name, order=2, style=dict(fontSize='var(--mantine-h1-font-size')),
+    dmc.Title(f'Round {number}', order=1, style=dict(fontSize='var(--mantine-h2-font-size'), c='dimmed'),
+    dmc.Title(name, order=2, style=dict(fontSize='var(--mantine-h1-font-size')),
+    dmc.Text(f'Date completed: {date}', c='dimmed', style=dict(fontStyle='italic')),
   ], gap=0)
 
 
@@ -328,12 +328,17 @@ def update_round_summary(round_number, pathname):
     return f'Round {round_number}', 'No data.', []
 
   round_name = this_round.get('name')
+  round_date = this_round.get('date')
 
   report = this_round.get('report') or '...'
   insights = this_round.get('insights') or []
   methods = this_round.get('methods') or '...'
   return (
-    round_heading(round_number, round_name),
+    round_heading(
+      number=round_number,
+      date=round_date,
+      name=round_name,
+    ),
     dcc.Markdown(report),
     [insight_button(i) for i in insights],
     dcc.Markdown(methods),

--- a/src/components/toolbar.py
+++ b/src/components/toolbar.py
@@ -1,0 +1,71 @@
+import dash_mantine_components as dmc
+from dash import html
+
+
+def toolbar(
+  left=None,
+  right=None,
+  *,
+  variant='soft',
+  p='xs',
+  mt=16,
+  mb=24,
+  gap='xs',
+  justify='space-between',
+  align='center',
+):
+  '''
+  Toolbar component.
+
+  Parameters
+  ----------
+  left : Component | list[Component] | None
+    Elements aligned to the left side (e.g., Back button).
+  right : Component | list[Component] | None
+    Elements aligned to the right side (e.g., Download, Explorer buttons).
+  variant : str, default='soft'
+    Mantine Card variant.
+  p : str or int, default='xs'
+    Card padding.
+  mt : str or int | None
+    Top margin.
+  mb : str or int, default=24
+    Bottom margin.
+  gap : str, default='xs'
+    Gap between elements in left/right groups.
+  justify : str, default='space-between'
+    Flex item justification.
+  align : str, default='center'
+    Flex item alignment.
+
+  Returns
+  -------
+  dmc.Card
+  '''
+
+  # normalize left and right to lists
+  if left is None:
+    left = []
+  elif not isinstance(left, (list, tuple)):
+    left = [left]
+
+  if right is None:
+    right = []
+  elif not isinstance(right, (list, tuple)):
+    right = [right]
+
+  # inner layout
+  return dmc.Card(
+    dmc.Flex(
+      children=[
+        dmc.Flex(left, gap=gap) if left else html.Div(),
+        dmc.Flex(right, gap=gap) if right else html.Div(),
+      ],
+      justify=justify,
+      align=align,
+    ),
+    variant=variant,
+    p=p,
+    mt=mt,
+    mb=mb,
+  )

--- a/src/data/rounds/round18/details.yaml
+++ b/src/data/rounds/round18/details.yaml
@@ -1,5 +1,6 @@
 round_number: 18
 name: "Round does not contain data"
+date: June 4, 2024
 report: >
   In the 18th Round of COVID-19 scenario projections, the US COVID-19 Scenario
   Modeling Hub aimed to estimate the impact Quis aliquip culpa nostrud officia
@@ -8,3 +9,5 @@ report: >
   dolor voluptate commodo sit veniam. Lorem ipsum exercitation duis enim aliquip
   cillum id in qui nulla amet. Mollit dolor ut consectetur qui reprehenderit sunt
   adipisicing labore sit.
+methods: |
+  placeholder

--- a/src/data/rounds/round19/details.yaml
+++ b/src/data/rounds/round19/details.yaml
@@ -1,5 +1,6 @@
 round_number: 19
 name: "Vaccine Recommendation Levels"
+date: June 4, 2025
 report: >
   In the 19th Round of COVID-19 scenario projections, the US COVID-19 Scenario
   Modeling Hub aimed to estimate the impact of three vaccine recommendation

--- a/src/pages/explorer.py
+++ b/src/pages/explorer.py
@@ -10,6 +10,7 @@ from dash import (
 )
 from dash_iconify import DashIconify
 
+from src.components.toolbar import toolbar
 from src.components.save_insight_form import save_insight_form
 from src.components.viz_editor import visualization_editor
 from src.data.rounds.round19 import get_insight
@@ -17,20 +18,28 @@ from src.util.get_query_param import get_query_param
 
 register_page(__name__, path_template='/explorer', name='Insight Explorer')
 
-back_button = dmc.Anchor('← Abandon Changes', href='/', id='back-button')
+back_button = dmc.Anchor(
+  dmc.Button(
+    'Abandon Changes',
+    leftSection=DashIconify(icon='feather:chevron-left'),
+    variant='light',
+    size='xs',
+  ),
+  id='back-button',
+  href='/',
+)
 
 reset_button = dmc.Button(
   'Reset to Original',
   id='reset-button',
   leftSection=DashIconify(icon='feather:refresh-ccw'),
-  variant='outline',
+  variant='light',
+  size='xs'
 )
 
-insight_toolbar = dmc.Flex(
-  children=[back_button, dmc.Group([reset_button])],
-  justify='space-between',
-  align='center',
-  mb=24,
+insight_toolbar = toolbar(
+  left=[back_button],
+  right=[reset_button],
 )
 
 

--- a/src/pages/insight.py
+++ b/src/pages/insight.py
@@ -18,14 +18,63 @@ from dash_iconify import DashIconify
 from src.components.tooltip import tooltip
 from src.components.viz_editor import visualization_editor
 from src.data.rounds.round19 import get_insight
+from src.util.data import load_rounds
 from src.util.export.pdf import generate_insight_pdf
 from src.util.slugify import slugify
 
 register_page(__name__, path_template='/insight/<insight_id>', name='Insight Details')
 
+
+back_button = dmc.Anchor(
+  dmc.Button(
+    'Round Summary',
+    leftSection=DashIconify(icon='feather:chevron-left'),
+    variant='light',
+    size='xs',
+  ),
+  id='back-to-insights-button',
+  href='/',
+)
+
+
+download_button = dmc.Button(
+  'PDF',
+  leftSection=DashIconify(icon='feather:download'),
+  id='download-insight-button',
+  variant='light',
+  size='xs',
+  loading=False,
+)
+
+
+explorer_button = dmc.Anchor(
+  dmc.Button(
+    'Explore',
+    leftSection=DashIconify(icon='feather:arrow-up-right'),
+    variant='gradient',
+    size='xs',
+    gradient={'from': 'lime', 'to': 'teal', 'deg': 120},
+  ),
+  id='explorer-button',
+  href='#',
+)
+
+
+insight_toolbar = dmc.Card([
+  dmc.Flex(
+    children=[
+      back_button,
+      dmc.Flex([download_button, explorer_button], gap='xs'),
+    ],
+    justify='space-between',
+    align='center',
+  )], variant='soft', p='xs', mt=16, mb=24)
+
+
 loading_insight = [
-  dmc.Title(id='insight-view-title', order=1, children=dmc.Skeleton(h=85)),
-  dmc.Divider(my=24),
+  dmc.Space(h=16),
+  dmc.Title(id='insight-view-title', order=1, children=dmc.Skeleton(h=82)),
+  insight_toolbar,
   html.Div(
     id='insight-view-figure-container',
     children=dmc.Stack(
@@ -41,48 +90,19 @@ loading_insight = [
   dcc.Download(id='insight-pdf-download'),
 ]
 
-back_button = dmc.Anchor(
-  '← Back to Round Overview',
-  id='back-to-insights-button',
-  href='/',
-)
 
-explorer_button = dcc.Link(
-  dmc.Button(
-    'Explore',
-    leftSection=DashIconify(icon='feather:arrow-up-right'),
-  ),
-  id='explorer-button',
-  href='#',
-)
-
-download_button = dmc.ActionIcon(
-  DashIconify(icon='feather:download'),
-  variant='subtle',
-  id='download-insight-button',
-  size='lg',
-  loading=False,
-)
-
-insight_toolbar = dmc.Flex(
-  children=[
-    back_button,
-    dmc.Group(
-      [
-        tooltip(download_button, label='Download PDF'),
-        tooltip(explorer_button, label="Explore this insight's data"),
-      ]
-    ),
-  ],
-  justify='space-between',
-  align='center',
-  mb=24,
-)
+def insight_heading(round_number: str, round_date: str, round_name: str):
+  return dmc.Stack([
+    dmc.Text(f'Round {round_number}', style=dict(fontSize='var(--mantine-h3-font-size'), c='dimmed', fw=700, mb=8),
+    dmc.Flex([
+      dmc.Text(round_name, style=dict(fontSize='var(--mantine-h2-font-size'), fw=700),
+      dmc.Text(f'Date completed: {round_date}', c='dimmed', style=dict(fontStyle='italic')),
+    ], justify='space-between', align='flex-end'),
+  ], gap=0)
 
 
 layout = dmc.Container(
   children=[
-    insight_toolbar,
     dmc.Box(
       loading_insight,
       id='insight-view-container',
@@ -123,11 +143,24 @@ def show_insight_details(pathname, custom_insights):
     if not insight:
       raise ValueError(f'Insight {insight_id} not found')
 
+
     controls = insight.get('controls', {})
+    round_number = str(controls['round_num'])
+
+    rounds = load_rounds()
+    this_round = rounds.get(round_number)
+    if not this_round:
+      raise exceptions.PreventUpdate
 
     return [
-      dmc.Title(insight.get('title', 'Untitled Insight'), order=1),
-      dmc.Divider(my=24),
+      dmc.Space(h=16),
+      insight_heading(
+        round_number=round_number,
+        round_date=this_round.get('date'),
+        round_name=this_round.get('name'),
+      ),
+      insight_toolbar,
+      dmc.Title(f'Insight: {insight.get('title', 'Untitled Insight')}', order=1),
       html.Div(
         visualization_editor(control_values=controls, show_controls=False),
         style=dict(margin='24px 0'),

--- a/src/pages/insight.py
+++ b/src/pages/insight.py
@@ -16,6 +16,7 @@ from dash import (
 from dash_iconify import DashIconify
 
 from src.components.tooltip import tooltip
+from src.components.toolbar import toolbar
 from src.components.viz_editor import visualization_editor
 from src.data.rounds.round19 import get_insight
 from src.util.data import load_rounds
@@ -60,15 +61,10 @@ explorer_button = dmc.Anchor(
 )
 
 
-insight_toolbar = dmc.Card([
-  dmc.Flex(
-    children=[
-      back_button,
-      dmc.Flex([download_button, explorer_button], gap='xs'),
-    ],
-    justify='space-between',
-    align='center',
-  )], variant='soft', p='xs', mt=16, mb=24)
+insight_toolbar = toolbar(
+  left=[back_button],
+  right=[download_button, explorer_button]
+)
 
 
 loading_insight = [

--- a/src/util/data.py
+++ b/src/util/data.py
@@ -34,6 +34,7 @@ def load_rounds():
       continue
 
     round_number = dirname.replace('round', '')
+    round_date = dirname.replace('date', '')
     rounds_path = os.path.join(ROUNDS_DIR, dirname)
     details_path = os.path.join(rounds_path, 'details.yaml')
     insights_path = os.path.join(rounds_path, 'insights')
@@ -48,6 +49,7 @@ def load_rounds():
     rounds[round_number] = dict(
       round_number=int(round_number),
       name=details.get('name'),
+      date=details.get('date'),
       report=details.get('report', ''),
       insights=insights,
       methods=details.get('methods', ''),

--- a/src/util/export/pdf.py
+++ b/src/util/export/pdf.py
@@ -1,7 +1,9 @@
 import os
 import markdown
 from weasyprint import HTML
+
 from src.util.assets import asset_uri
+from src.util.data import load_rounds
 
 LOGO_URI = asset_uri('images/covid19-smh-logo.png')
 
@@ -28,6 +30,7 @@ def md_to_html(md_text: str) -> str:
 
 def generate_round_pdf(round_dict):
   round_number = round_dict.get('round_number') or '18'
+  date = round_dict.get('date') or '...'
 
   summary_md = round_dict.get('report') or 'Report not found'
   summary_html = md_to_html(summary_md)
@@ -53,7 +56,7 @@ def generate_round_pdf(round_dict):
     <header>
       <div class="header-title">
         <h1 class="title">Round {round_number}<br />Executive Summary Report</h1>
-        <div class="subtitle">Round completed: June 4, 2025</div>
+        <div class="subtitle">Round completed: {date}</div>
       </div>
       <img src="{LOGO_URI}" alt="SMH Logo" class="header-smh-logo" />
     </header>
@@ -82,11 +85,15 @@ def generate_insight_pdf(insight):
   controls = insight.get('controls', {})
   round_number = controls.get('round', '18')
 
+  rounds = load_rounds()
+  this_round = rounds.get(round_number)
+  round_date = this_round.get('date', '...')
+
   body = f"""
     <header>
       <div class="header-title">
         <h1 class="title">Round {round_number}<br />Insight Report:<br />{title}</h1>
-        <div class="subtitle">Round completed: June 4, 2025</div>
+        <div class="subtitle">Round completed: {round_date}</div>
       </div>
       <img src="{LOGO_URI}" alt="SMH Logo" class="header-smh-logo" />
     </header>


### PR DESCRIPTION
This PR aims to close #64 by adding the round title and date in various places within the application:
- in the round summary view
- in the insight views
- in the round select
- in the PDF export

A few additional tweaks are coming along with this PR. In an effort to align the look and feel across our three views..
- there's a `toolbar` component to house the action buttons for each view (i think the insight save button ccan eventually land in here);
- buttons that take the user to the explorer have consistent styles;
- button styles (variant, icon, icon placement) are aligned app-wide

