### PR TITLE
Add insight summary to insight cards

### DIFF
--- a/src/components/round_summary.py
+++ b/src/components/round_summary.py
@@ -109,6 +109,7 @@ def insight_button(item):
   )
 
   title = dmc.Text(item['title'], size='lg', style=dict(whiteSpace='normal', textAlign='left'))
+  summary = dmc.Text(item['summary'], c='dimmed')
 
   view_button = dmc.Anchor(
     dmc.Button(
@@ -130,7 +131,7 @@ def insight_button(item):
     [
       graphic,
       dmc.Stack(
-        [title],
+        [title, summary],
         align='flex-start',
         style=dict(flex=1, overflow='hidden'),
       ),

--- a/src/pages/insight.py
+++ b/src/pages/insight.py
@@ -127,7 +127,7 @@ def show_insight_details(pathname, custom_insights):
 
     return [
       dmc.Title(insight.get('title', 'Untitled Insight'), order=1),
-      dmc.Text(insight.get('summary', 'Summary not found'), c='dimmed'),
+      dmc.Text(insight.get('summary', 'Summary not found')),
       dmc.Divider(my=24),
       html.Div(
         visualization_editor(control_values=controls, show_controls=False),

--- a/src/pages/insight.py
+++ b/src/pages/insight.py
@@ -127,6 +127,7 @@ def show_insight_details(pathname, custom_insights):
 
     return [
       dmc.Title(insight.get('title', 'Untitled Insight'), order=1),
+      dmc.Text(insight.get('summary', 'Summary not found'), c='dimmed'),
       dmc.Divider(my=24),
       html.Div(
         visualization_editor(control_values=controls, show_controls=False),


### PR DESCRIPTION
This PR simply adds the insight summaries to:
- the insight cards and
- the single insight view.

We discussed this briefly in Slack.

<img width="518" height="411" alt="image" src="https://github.com/user-attachments/assets/087577ca-a0ba-45d3-b8e7-0acb8a2dad47" />

<img width="478" height="372" alt="image" src="https://github.com/user-attachments/assets/f90f6cd2-a4da-4f9a-9e7e-db0b9a5c8870" />
