### PR TITLE
Reference annotations from insight description

### DIFF
--- a/assets/markdown-annotation.css
+++ b/assets/markdown-annotation.css
@@ -1,0 +1,11 @@
+.vertical-annotation {
+    display: inline-block; 
+    padding-left: 0.1em;
+    border-left: 1px dashed;
+    font-style: italic;
+}
+
+.horizontal-annotation {
+    border-bottom: 1px dashed;
+    font-style: italic;
+}

--- a/assets/markdown-annotation.css
+++ b/assets/markdown-annotation.css
@@ -1,5 +1,4 @@
 .vertical-annotation {
-    display: inline-block; 
     padding-left: 0.1em;
     border-left: 1px dashed;
     font-style: italic;

--- a/src/data/rounds/round19/insights/seasonal-burden-and-trajectory.yaml
+++ b/src/data/rounds/round19/insights/seasonal-burden-and-trajectory.yaml
@@ -7,6 +7,12 @@ description: >
   - **648,000 cumulative hospitalizations (95% PI 241,000–778,000) and 40,000 deaths (95% PI 25,000-59,000)** due to COVID-19 projected from April 27, 2025 to April 25, 2026 in the high-risk vaccination scenario (i.e., booster vaccination only among individuals aged 65+ or otherwise at high risk for elevated severity).
 
   - **The majority of hospitalization and death burden from COVID-19 is expected to occur in individuals 65+**:  56% of hospitalizations and 84% of deaths occur among 65+ in the high-risk vaccination scenario.
+
+
+  Note that all values after <div style='display: inline-block; height: 1.5em; width: 1px; border-left: 1px dashed #993366; vertical-align: middle;' /> *Some Policy change* are...
+
+
+  Also note the interesting value at <span style='font-style: italic; border-bottom: 1px dashed #663399;' children='Value for seasonal-burden-and-trajectory insight.' />
 image_url: assets/images/insight-preview/insight-5.png
 template: default
 created_at: "2025-05-18T22:45:12Z"

--- a/src/data/rounds/round19/insights/seasonal-burden-and-trajectory.yaml
+++ b/src/data/rounds/round19/insights/seasonal-burden-and-trajectory.yaml
@@ -9,10 +9,10 @@ description: >
   - **The majority of hospitalization and death burden from COVID-19 is expected to occur in individuals 65+**:  56% of hospitalizations and 84% of deaths occur among 65+ in the high-risk vaccination scenario.
 
 
-  Note that all values after <div class='vertical-annotation' style='border-color: #993366;' children='Some Policy change' /> are...
+  Note that all values after <span class='vertical-annotation' style='border-color: #993366;' children='Some Policy change' /><pdfonly><span style='padding-left: 0.1em; border-left: 1px dashed; font-style: italic; border-color: #993366;'>Some Policy change</span></pdfonly> are...
 
 
-  Also note the interesting value at <span class='horizontal-annotation' style='border-color: #663399;' children='Value for seasonal-burden-and-trajectory insight' />.
+  Also note the interesting value at <span class='horizontal-annotation' style='border-color: #663399;' children='Value for seasonal-burden-and-trajectory insight' /><pdfonly><span style='border-bottom: 1px dashed; font-style: italic; border-color: #663399;'>Value for seasonal-burden-and-trajectory insight</span></pdfonly>.
 image_url: assets/images/insight-preview/insight-5.png
 template: default
 created_at: "2025-05-18T22:45:12Z"

--- a/src/data/rounds/round19/insights/seasonal-burden-and-trajectory.yaml
+++ b/src/data/rounds/round19/insights/seasonal-burden-and-trajectory.yaml
@@ -9,10 +9,10 @@ description: >
   - **The majority of hospitalization and death burden from COVID-19 is expected to occur in individuals 65+**:  56% of hospitalizations and 84% of deaths occur among 65+ in the high-risk vaccination scenario.
 
 
-  Note that all values after <span class='vertical-annotation' style='border-color: #993366;' children='Some Policy change' /><pdfonly><span style='padding-left: 0.1em; border-left: 1px dashed; font-style: italic; border-color: #993366;'>Some Policy change</span></pdfonly> are...
+  Note that all values after <span class='vertical-annotation' style='border-color: #993366;' children='Some Policy change' /><pdfonly><span class='vertical-annotation-pdf' style='border-color: #993366;'>Some Policy change</span></pdfonly> are...
 
 
-  Also note the interesting value at <span class='horizontal-annotation' style='border-color: #663399;' children='Value for seasonal-burden-and-trajectory insight' /><pdfonly><span style='border-bottom: 1px dashed; font-style: italic; border-color: #663399;'>Value for seasonal-burden-and-trajectory insight</span></pdfonly>.
+  Also note the interesting value at <span class='horizontal-annotation' style='border-color: #663399;' children='Value for seasonal-burden-and-trajectory insight' /><pdfonly><span class='horizontal-annotation-pdf' style='border-color: #663399;'>Value for seasonal-burden-and-trajectory insight</span></pdfonly>.
 image_url: assets/images/insight-preview/insight-5.png
 template: default
 created_at: "2025-05-18T22:45:12Z"

--- a/src/data/rounds/round19/insights/seasonal-burden-and-trajectory.yaml
+++ b/src/data/rounds/round19/insights/seasonal-burden-and-trajectory.yaml
@@ -9,10 +9,10 @@ description: >
   - **The majority of hospitalization and death burden from COVID-19 is expected to occur in individuals 65+**:  56% of hospitalizations and 84% of deaths occur among 65+ in the high-risk vaccination scenario.
 
 
-  Note that all values after <div style='display: inline-block; height: 1.5em; width: 1px; border-left: 1px dashed #993366; vertical-align: middle;' /> *Some Policy change* are...
+  Note that all values after <div class='vertical-annotation' style='border-color: #993366;' children='Some Policy change' /> are...
 
 
-  Also note the interesting value at <span style='font-style: italic; border-bottom: 1px dashed #663399;' children='Value for seasonal-burden-and-trajectory insight.' />
+  Also note the interesting value at <span class='horizontal-annotation' style='border-color: #663399;' children='Value for seasonal-burden-and-trajectory insight' />.
 image_url: assets/images/insight-preview/insight-5.png
 template: default
 created_at: "2025-05-18T22:45:12Z"

--- a/src/pages/insight.py
+++ b/src/pages/insight.py
@@ -162,7 +162,7 @@ def show_insight_details(pathname, custom_insights):
         visualization_editor(control_values=controls, show_controls=False),
         style=dict(margin='24px 0'),
       ),
-      dcc.Markdown(insight.get('description', '')),
+      dcc.Markdown(insight.get('description', ''), dangerously_allow_html=True),
       dcc.Download(id='insight-pdf-download'),
     ]
 

--- a/src/pages/insight.py
+++ b/src/pages/insight.py
@@ -22,6 +22,7 @@ from src.data.rounds.round19 import get_insight
 from src.util.data import load_rounds
 from src.util.export.pdf import generate_insight_pdf
 from src.util.slugify import slugify
+import re
 
 register_page(__name__, path_template='/insight/<insight_id>', name='Insight Details')
 
@@ -148,6 +149,10 @@ def show_insight_details(pathname, custom_insights):
     if not this_round:
       raise exceptions.PreventUpdate
 
+    # Clean description by removing <pdfonly> tags
+    description_md = insight.get('description', '')
+    description_md = re.sub(r'<pdfonly>.*?</pdfonly>', '', description_md, flags=re.DOTALL | re.IGNORECASE)
+
     return [
       dmc.Space(h=16),
       insight_heading(
@@ -162,7 +167,7 @@ def show_insight_details(pathname, custom_insights):
         visualization_editor(control_values=controls, show_controls=False),
         style=dict(margin='24px 0'),
       ),
-      dcc.Markdown(insight.get('description', ''), dangerously_allow_html=True),
+      dcc.Markdown(description_md, dangerously_allow_html=True),
       dcc.Download(id='insight-pdf-download'),
     ]
 

--- a/src/util/export/pdf.css
+++ b/src/util/export/pdf.css
@@ -66,7 +66,7 @@ main {
     border-left: 1px dashed;
     font-style: italic;
 }
-.horizontal-annotation {
+.horizontal-annotation-pdf {
     border-bottom: 1px dashed;
     font-style: italic;
 }

--- a/src/util/export/pdf.css
+++ b/src/util/export/pdf.css
@@ -61,3 +61,12 @@ main {
     }
   }
 }
+.vertical-annotation-pdf {
+    padding-left: 0.1em;
+    border-left: 1px dashed;
+    font-style: italic;
+}
+.horizontal-annotation {
+    border-bottom: 1px dashed;
+    font-style: italic;
+}


### PR DESCRIPTION
Add example of referencing annotations from insight description using html styling. Using inline div for vertical, and span for horizontal. Needed to add `dangerously_allow_html=True` to `dcc.Markdown`