### PR TITLE
Allow insight ordering

### DIFF
--- a/src/data/rounds/round19/insights/seasonal-burden-and-trajectory.yaml
+++ b/src/data/rounds/round19/insights/seasonal-burden-and-trajectory.yaml
@@ -1,5 +1,6 @@
 id: seasonal-burden-and-trajectory
 title: Seasonal Burden and Trajectory
+order: 1
 summary: We expect continued substantial burden of disease from COVID-19 in the US, with two periods of increased COVID-19, in late summer/early fall 2025 and winter 2025-26.
 description: >
   Note the difference in peak hospitalization for the two scenarios. Looking at the <span data-annotation-ref="time of max w no booster" style="color:#993366">time of peak hospitalizations</span>, we see the <span data-annotation-ref="max w no booster" style="color:#00abc7">projected peak hospitalizations</span> in the _No booster scenario_ exceeds that of the _65+ and high-risk booster scenario_ by about 14,600.

--- a/src/data/rounds/round19/insights/vaccination-impact.yaml
+++ b/src/data/rounds/round19/insights/vaccination-impact.yaml
@@ -1,5 +1,6 @@
 id: vaccination-impact
 title: Vaccination Impact
+order: 2
 summary: All vaccination strategies are projected to significantly reduce disease burden. The greatest benefits will be seen if vaccines are offered to all ages.
 description: >
   - **Both vaccination strategies are projected to significantly reduce disease burden compared to no vaccination.**

--- a/src/util/data.py
+++ b/src/util/data.py
@@ -17,11 +17,18 @@ def load_insights(path):
     if filename.endswith('.yaml'):
       filepath = os.path.join(path, filename)
       with open(filepath, 'r') as f:
-        insight = yaml.safe_load(f)
+        insight = yaml.safe_load(f) or {}
         insight['type'] = 'system'
         insights.append(insight)
 
-  insights.sort(key=lambda x: x.get('title', '').lower())
+  # sort by `order`, then by `title`
+  insights.sort(
+    key=lambda x: (
+      x.get('order', float('inf')),
+      x.get('title', '').lower(),
+    )
+  )
+
   return insights
 
 


### PR DESCRIPTION
This PR adds optional ordering to the YAML insight files ingested by the application.
Previously, insights were sorted alphabetically by their lowercased titles. This change introduces an `order` field to the insight YAML files to control display ordering. 

```yaml
title: Vaccination Impact
order: 3
description: >
  Lorem ipsum ...
```

If not preset, ordering falls back to ordering by title, meaning we aren't introducing  breaking changes.
