### PR TITLE
Remove zoom controls

### DIFF
--- a/src/components/chart/line_chart.py
+++ b/src/components/chart/line_chart.py
@@ -274,7 +274,6 @@ class LineChart(Chart):
     self.refresh_fig()
 
   def _plot_uncertainty_interval(self, scenario_df: pd.DataFrame, model: Model, row_num: int):
-    print(self.controls.uncertainty_interval)
     for lower_q, upper_q in self.controls.uncertainty_interval.get_bounds():
       lower_model = scenario_df.query('type_id == @lower_q and model_name == @model.id')
       upper_model = scenario_df.query('type_id == @upper_q and model_name == @model.id')

--- a/src/components/viz_editor/visualization_editor.py
+++ b/src/components/viz_editor/visualization_editor.py
@@ -85,7 +85,8 @@ def visualization_editor(controls=None, show_controls=True):
   chart_controls = ChartControls.from_dict(controls_dict)
   chart = chart_manager.get_chart(chart_controls)
   figure = chart.get_fig() if chart else go.Figure()
-  graph = dcc.Graph(id='graph', figure=figure)
+  graph = dcc.Graph(id='graph', figure=figure, 
+                    config={'modeBarButtonsToRemove': ['toImage', 'pan2d', 'lasso2d', 'select2d', 'autoScale2d'], 'displaylogo': False},)
 
   if not chart:
     return html.Div(
@@ -137,11 +138,13 @@ def visualization_editor(controls=None, show_controls=True):
               ),
               variant='soft',
             ),
-            dmc.Card(
-              zoom_control(value=init_zoom),
-              variant='soft',
-              style={'display': 'none'} if init_plot_type == 'boxplot' else {},
-            ),
+            #dmc.Card(
+            #  zoom_control(value=init_zoom),
+            #  variant='soft',
+            #  style={'display': 'none'} if init_plot_type == 'boxplot' else {},
+            #),
+            # Remove zoom control for now, but render the Store to keep things in sync
+            dcc.Store(id='zoom-store', data=init_zoom),
             dmc.Card(
               annotations_control(value=init_annotations),
               variant='soft',


### PR DESCRIPTION
Remove zoom GUI controls until we have some more time to get them working the way we want.

1. Removed zoom control display, rendering just the zoom-store instead to keep things synchronized
2. Kept only zoom controls in the plotly toolbar