### PR TITLE
Remove unnecessary svg elements on save

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "python-slugify>=8.0.4",
     "pyyaml>=6.0.2",
     "weasyprint>=66.0",
+    "beautifulsoup4>=4.12.3",
 ]
 
 [dependency-groups]

--- a/src/components/save_insight_form.py
+++ b/src/components/save_insight_form.py
@@ -6,6 +6,8 @@ import dash_mantine_components as dmc
 from dash import Input, Output, State, callback, clientside_callback, dcc, exceptions
 from dash_iconify import DashIconify
 
+from src.util.svg import clean_svg
+
 default_control_values = {
   'theme': 'light',
   'plot_type': 'line',
@@ -138,7 +140,8 @@ def save_custom_insight(
 
   now = datetime.datetime.now(datetime.timezone.utc).isoformat()
   new_id = f'custom-{uuid.uuid4()}'
-  image_url = thumbnail_data or 'https://placehold.co/400?text=Visualization'
+  cleaned_thumbnail_data = clean_svg(thumbnail_data)
+  image_url = cleaned_thumbnail_data or 'https://placehold.co/400?text=Visualization'
   new_item = dict(
     id=new_id,
     title=title.strip(),

--- a/src/util/svg.py
+++ b/src/util/svg.py
@@ -1,0 +1,57 @@
+import base64
+import urllib.parse
+from bs4 import BeautifulSoup
+
+
+def clean_svg(svg_data_uri: str) -> str:
+  """
+  Cleans an SVG data URI by removing unnecessary elements.
+
+  Args:
+    svg_data_uri: A string representing the SVG as a data URI.
+
+  Returns:
+    A cleaned SVG data URI string.
+  """
+  print(svg_data_uri)
+  if not svg_data_uri or not svg_data_uri.startswith('data:image/svg+xml'):
+    return svg_data_uri
+
+  header, encoded_data = svg_data_uri.split(',', 1)
+
+  decoded_svg = urllib.parse.unquote(encoded_data)
+
+  soup = BeautifulSoup(decoded_svg, 'html.parser')
+
+  # remove all text, title, and defs elements
+  for tag_name in ['text', 'title', 'defs']:
+    for tag in soup.find_all(tag_name):
+      tag.decompose()
+
+  for element in soup.find('g', class_='bglayer'): element.decompose()
+  for element in soup.find('g', class_='layer-below'): element.decompose()
+  for element in soup.find('g', class_='polarlayer'): element.decompose()
+  for element in soup.find('g', class_='smithlayer'): element.decompose()
+  for element in soup.find('g', class_='ternarylayer'): element.decompose()
+  for element in soup.find('g', class_='geolayer'): element.decompose()
+  for element in soup.find('g', class_='funnelarealayer'): element.decompose()
+  for element in soup.find('g', class_='pielayer'): element.decompose()
+  for element in soup.find('g', class_='iciclelayer'): element.decompose()
+  for element in soup.find('g', class_='treemaplayer'): element.decompose()
+  for element in soup.find('g', class_='sunburstlayer'): element.decompose()
+  for element in soup.find('g', class_='glimages'): element.decompose()
+
+  # plotly specific: remove the top-level info layer which contains legends and titles
+  for info_layer in soup.find_all('g', class_='infolayer'):
+    info_layer.decompose()
+  
+  # remove style elements not needed for basic visuals
+  for style in soup.find_all('style'):
+    style.decompose()
+
+  cleaned_svg_string = str(soup)
+
+  encoded_cleaned_svg = urllib.parse.quote(cleaned_svg_string)
+
+  return f'{header},{encoded_cleaned_svg}'
+

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,19 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.12"
+
+[[package]]
+name = "beautifulsoup4"
+version = "4.14.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "soupsieve" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b0/1c6a16426d389813b48d95e26898aff79abbde42ad353958ad95cc8c9b21/beautifulsoup4-4.14.3.tar.gz", hash = "sha256:6292b1c5186d356bba669ef9f7f051757099565ad9ada5dd630bd9de5fa7fb86", size = 627737, upload-time = "2025-11-30T15:08:26.084Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl", hash = "sha256:0918bfe44902e6ad8d57732ba310582e98da931428d231a5ecb9e7c703a735bb", size = 107721, upload-time = "2025-11-30T15:08:24.087Z" },
+]
 
 [[package]]
 name = "blinker"
@@ -706,6 +719,7 @@ name = "public-health-app"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
+    { name = "beautifulsoup4" },
     { name = "dash" },
     { name = "dash-ag-grid" },
     { name = "dash-iconify" },
@@ -727,6 +741,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "beautifulsoup4", specifier = ">=4.12.3" },
     { name = "dash", specifier = ">=3.2.0" },
     { name = "dash-ag-grid", specifier = ">=32.3.1" },
     { name = "dash-iconify", specifier = ">=0.1.2" },
@@ -916,6 +931,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "soupsieve"
+version = "2.8"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6d/e6/21ccce3262dd4889aa3332e5a119a3491a95e8f60939870a3a035aabac0d/soupsieve-2.8.tar.gz", hash = "sha256:e2dd4a40a628cb5f28f6d4b0db8800b8f581b65bb380b97de22ba5ca8d72572f", size = 103472, upload-time = "2025-08-27T15:39:51.78Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/a0/bb38d3b76b8cae341dad93a2dd83ab7462e6dbcdd84d43f54ee60a8dc167/soupsieve-2.8-py3-none-any.whl", hash = "sha256:0cc76456a30e20f5d7f2e14a98a4ae2ee4e5abdc7c5ea0aafe795f344bc7984c", size = 36679, upload-time = "2025-08-27T15:39:50.179Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
we're currently saving an SVG as data URi string in the insights. this is fine (as in, it works), but it's worth cleaning this up a bit to (1) reduce required space and (2) reduce visual clutter when this image gets rendered in a 150px-wide box, as you really only are processing the graphical elements when using that little image.

here are two SVGs for two insights using the same data and controls. the first is using _this_ branch with cleaned SVG, and the second is using the current save implementation.

<img width="533" height="536" alt="image" src="https://github.com/user-attachments/assets/1f50083d-33fd-4aeb-bf54-92b9f32aa055" />

the clean SVG has a bunch of superfluous layers removed, as well as textual elements that would be invisible anyway.

additionally, cleaning the SVG string reduces its length by about 16,000 characters--56,717 ->40,344. there's still loads we can do here, simplifying curves probably being the main one.

note: a new dependency, beautifulsoup, is introduced to handle html element removal

this is slightly related to #107, which has a PR #114 addressing the image fit, so it may make sense for this branch and that one to be merged.
