### PR TITLE
Feature/grid ordering

### DIFF
--- a/src/components/chart/line_chart.py
+++ b/src/components/chart/line_chart.py
@@ -41,8 +41,6 @@ class LineChart(Chart):
       return self._fig
 
     # update layout
-    num_scenarios = len(self.controls.scenarios)
-
     if self.controls.chart_layout == ChartLayout.STACK:
       num_cols = 1
     elif self.controls.chart_layout == ChartLayout.GRID:
@@ -59,9 +57,6 @@ class LineChart(Chart):
       get_scenario_letter(self.controls.scenarios[-1].name),
       num_cols,
     )[0]
-
-    print(num_rows)
-    # num_rows = (num_scenarios + num_cols - 1) // num_cols
 
     # Define fixed dimensions
     SUBPLOT_HEIGHT = 300  # Fixed height per subplot in pixels
@@ -91,28 +86,29 @@ class LineChart(Chart):
     gold_std_df = gold_std_df.query('geo_value_fullname == @self.controls.location.name')
     gold_std_df = gold_std_df.loc[self.controls.x_start_date or gold_std_df.index.min() :]
 
+    # Get titles in correct layout
+    subplot_titles = [""] * (num_rows * num_cols)
+    for scenario in self.controls.scenarios:
+      scenario_letter = get_scenario_letter(scenario.name)
+
+      # Use one column because titles are provided in a list
+      scenario_row = get_scenario_position(scenario_letter, 1)
+
+      subplot_titles[scenario_row[0] - 1] = f'{scenario_letter}. {scenario.description}'
+
     # create subplots
     self._fig = make_subplots(
       rows=num_rows,
       cols=num_cols,
       vertical_spacing=vertical_spacing,
       row_heights=[1] * num_rows,
-      subplot_titles=[f'{s.name.split("-")[0]}. {s.description}' for s in self.controls.scenarios],
+      subplot_titles=subplot_titles,
     )
-
-    print(self.controls.scenarios)
 
     # add traces for each scenario
     for i, scenario in enumerate(self.controls.scenarios, start=1):
-      current_row = (i - 1) // num_cols + 1
-      current_col = (i - 1) % num_cols + 1
-
       scenario_letter = get_scenario_letter(scenario.name)
-      scenario_row, scenario_col = get_scenario_position(scenario_letter, num_cols)
-
-      current_row = scenario_row
-      current_col = scenario_col
-        
+      current_row, current_col = get_scenario_position(scenario_letter, num_cols)        
 
       # filter for given scenario
       scenario_df = df.query('scenario_id == @scenario.id')
@@ -129,6 +125,7 @@ class LineChart(Chart):
             model=model,
             row_num=current_row,
             col_num=current_col,
+            showlegend=(i == 1),
           )
         else:
           # add main line (0.5 quantile)
@@ -312,7 +309,7 @@ class LineChart(Chart):
     )
     self.refresh_fig()
 
-  def _plot_uncertainty_interval(self, scenario_df: pd.DataFrame, model: Model, row_num: int, col_num: int):
+  def _plot_uncertainty_interval(self, scenario_df: pd.DataFrame, model: Model, row_num: int, col_num: int, showlegend: bool):
     all_bounds = self.controls.uncertainty_interval.get_bounds()
     for i, bounds in enumerate(all_bounds):
       lower_q, upper_q = bounds
@@ -333,7 +330,7 @@ class LineChart(Chart):
           name=f'{model.name}',
           legendgroup=f'{model.name}',
           hoverinfo='skip',
-          showlegend=(row_num == 1 and col_num == 1 and i == len(all_bounds) - 1),
+          showlegend=(showlegend and i == len(all_bounds) - 1),
         ),
         row=row_num,
         col=col_num,

--- a/src/components/chart/line_chart.py
+++ b/src/components/chart/line_chart.py
@@ -41,6 +41,8 @@ class LineChart(Chart):
       return self._fig
 
     # update layout
+    num_scenarios = len(self.controls.scenarios)
+
     if self.controls.chart_layout == ChartLayout.STACK:
       num_cols = 1
     elif self.controls.chart_layout == ChartLayout.GRID:
@@ -52,8 +54,12 @@ class LineChart(Chart):
     def get_scenario_position(scenario_letter: chr, num_cols: int) -> tuple[int, int]:
       index = ord(scenario_letter) - ord('A')
       return (index // num_cols + 1, index % num_cols + 1)
-    
-    num_rows = get_scenario_position(
+
+    def get_scenario_title(scenario: str) -> str:
+      scenario_letter = get_scenario_letter(scenario.name)
+      return f'{scenario_letter}. {scenario.description}'
+
+    num_rows = num_scenarios if self.controls.chart_layout == ChartLayout.STACK else get_scenario_position(
       get_scenario_letter(self.controls.scenarios[-1].name),
       num_cols,
     )[0]
@@ -87,14 +93,19 @@ class LineChart(Chart):
     gold_std_df = gold_std_df.loc[self.controls.x_start_date or gold_std_df.index.min() :]
 
     # Get titles in correct layout
-    subplot_titles = [""] * (num_rows * num_cols)
-    for scenario in self.controls.scenarios:
-      scenario_letter = get_scenario_letter(scenario.name)
+    subplot_titles = []
+    if self.controls.chart_layout == ChartLayout.STACK:
+      for scenario in self.controls.scenarios:
+        subplot_titles.append(get_scenario_title(scenario))   
+    else:
+      subplot_titles = [""] * (num_rows * num_cols)
+      for scenario in self.controls.scenarios:
+        scenario_letter = get_scenario_letter(scenario.name)
 
-      # Use one column because titles are provided in a list
-      scenario_row = get_scenario_position(scenario_letter, 1)
+        # Use one column because titles are provided in a list
+        scenario_row = get_scenario_position(scenario_letter, 1)
 
-      subplot_titles[scenario_row[0] - 1] = f'{scenario_letter}. {scenario.description}'
+        subplot_titles[scenario_row[0] - 1] = get_scenario_title(scenario)
 
     # create subplots
     self._fig = make_subplots(
@@ -108,7 +119,14 @@ class LineChart(Chart):
     # add traces for each scenario
     for i, scenario in enumerate(self.controls.scenarios, start=1):
       scenario_letter = get_scenario_letter(scenario.name)
-      current_row, current_col = get_scenario_position(scenario_letter, num_cols)        
+
+      current_col = 1
+      current_row = 1
+      if self.controls.chart_layout == ChartLayout.STACK:
+        current_row = i
+        current_col = 1
+      else:
+        current_row, current_col = get_scenario_position(scenario_letter, num_cols)        
 
       # filter for given scenario
       scenario_df = df.query('scenario_id == @scenario.id')

--- a/src/components/chart/line_chart.py
+++ b/src/components/chart/line_chart.py
@@ -47,8 +47,21 @@ class LineChart(Chart):
       num_cols = 1
     elif self.controls.chart_layout == ChartLayout.GRID:
       num_cols = 2
+ 
+    def get_scenario_letter(scenario_name: str) -> chr:
+      return scenario_name.split('-')[0]
 
-    num_rows = (num_scenarios + num_cols - 1) // num_cols
+    def get_scenario_position(scenario_letter: chr, num_cols: int) -> tuple[int, int]:
+      index = ord(scenario_letter) - ord('A')
+      return (index // num_cols + 1, index % num_cols + 1)
+    
+    num_rows = get_scenario_position(
+      get_scenario_letter(self.controls.scenarios[-1].name),
+      num_cols,
+    )[0]
+
+    print(num_rows)
+    # num_rows = (num_scenarios + num_cols - 1) // num_cols
 
     # Define fixed dimensions
     SUBPLOT_HEIGHT = 300  # Fixed height per subplot in pixels
@@ -87,10 +100,19 @@ class LineChart(Chart):
       subplot_titles=[f'{s.name.split("-")[0]}. {s.description}' for s in self.controls.scenarios],
     )
 
+    print(self.controls.scenarios)
+
     # add traces for each scenario
     for i, scenario in enumerate(self.controls.scenarios, start=1):
       current_row = (i - 1) // num_cols + 1
       current_col = (i - 1) % num_cols + 1
+
+      scenario_letter = get_scenario_letter(scenario.name)
+      scenario_row, scenario_col = get_scenario_position(scenario_letter, num_cols)
+
+      current_row = scenario_row
+      current_col = scenario_col
+        
 
       # filter for given scenario
       scenario_df = df.query('scenario_id == @scenario.id')

--- a/src/components/viz_editor/controls/scenarios_select.py
+++ b/src/components/viz_editor/controls/scenarios_select.py
@@ -25,10 +25,22 @@ def scenarios_select(value: list[str] = default_option):
     comboboxProps={"shadow": "md"},
   )
 
+@callback(
+  Output('scenarios-select', 'value', allow_duplicate=True),
+  Input('scenarios-select', 'value'),
+  prevent_initial_call=True,
+)
+def on_scenarios_select_change(selected_values: list[str]):
+  if not selected_values:
+    return []
+  
+  # Keep selected values sorted for consistency
+  selected_values.sort()
+  return selected_values
 
 @callback(
   Output('scenarios-select', 'data'),
-  Output('scenarios-select', 'value'),
+  Output('scenarios-select', 'value', allow_duplicate=True),
   Input('selected-round-store', 'data'),
   prevent_initial_call=True,
 )


### PR DESCRIPTION
Addresses #117 

Currently only implemented for line plots. Does not include placeholders, just blank areas for missing scenarios.

Notes:

* Added a callback to the scenario multiselect to keep the selected values in order by id. The remainder of the changes assume that the selected scenarios are provided in this order. This does mean that the order in which scenarios are selected are not applied to the grid or stack layout.
* Added functions to extract the scenario letter, and then get the position based on that for grid layout. This does assume that the scenario name is in the format `X-NAME`. A more robust approach might be to store the position in the configuration for the scenarios.